### PR TITLE
Simplify Ceph API auth response struct

### DIFF
--- a/api.go
+++ b/api.go
@@ -159,12 +159,7 @@ type CephAPIAuthRequest struct {
 }
 
 type CephAPIAuthResponse struct {
-	Token             string              `json:"token"`
-	Username          string              `json:"username"`
-	Permissions       map[string][]string `json:"permissions,omitempty"`
-	PwdExpirationDate *string             `json:"pwdExpirationDate,omitempty"`
-	SSO               bool                `json:"sso"`
-	PwdUpdateRequired bool                `json:"pwdUpdateRequired"`
+	Token string `json:"token"`
 }
 
 func (c *CephAPIClient) Auth(ctx context.Context, username string, password string) (string, error) {


### PR DESCRIPTION
## Summary
- reduce the CephAPIAuthResponse type to only retain the token field used by the client
- keep authentication unmarshalling behavior unchanged and run gofmt

## Testing
- go fmt ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e81b6b9883268aeaa321f6e58957)