### PR TITLE
Remove email and suspended options from RGW user modify CLI

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -243,9 +243,7 @@ type RgwUserCreateOptions struct {
 
 type RgwUserModifyOptions struct {
 	DisplayName string
-	Email       string
 	MaxBuckets  *int
-	Suspended   *bool
 	Admin       *bool
 }
 
@@ -324,18 +322,8 @@ func (c *CephCLI) RgwUserModify(ctx context.Context, uid string, opts *RgwUserMo
 		if opts.DisplayName != "" {
 			args = append(args, "--display-name="+opts.DisplayName)
 		}
-		if opts.Email != "" {
-			args = append(args, "--email="+opts.Email)
-		}
 		if opts.MaxBuckets != nil {
 			args = append(args, fmt.Sprintf("--max-buckets=%d", *opts.MaxBuckets))
-		}
-		if opts.Suspended != nil {
-			if *opts.Suspended {
-				args = append(args, "--suspended")
-			} else {
-				args = append(args, "--suspended=0")
-			}
 		}
 		if opts.Admin != nil {
 			if *opts.Admin {


### PR DESCRIPTION
## Summary
- remove the email and suspended fields from the RGW user modify options
- drop the corresponding CLI flags when invoking radosgw-admin
- run gofmt on cli.go

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150a6a6714832693247beb8cbfb19a)