### PR TITLE
Simplify RGW user create options

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -233,12 +233,8 @@ type RgwUserInfo struct {
 }
 
 type RgwUserCreateOptions struct {
-	Email       string
-	MaxBuckets  *int
-	Suspended   bool
-	GenerateKey *bool
-	AccessKey   string
-	SecretKey   string
+	AccessKey string
+	SecretKey string
 }
 
 type RgwUserModifyOptions struct {
@@ -268,18 +264,6 @@ func (c *CephCLI) RgwUserCreate(ctx context.Context, uid, displayName string, op
 	args := []string{"--conf", c.confPath, "--format=json", "user", "create", "--uid=" + uid, "--display-name=" + displayName}
 
 	if opts != nil {
-		if opts.Email != "" {
-			args = append(args, "--email="+opts.Email)
-		}
-		if opts.MaxBuckets != nil {
-			args = append(args, fmt.Sprintf("--max-buckets=%d", *opts.MaxBuckets))
-		}
-		if opts.Suspended {
-			args = append(args, "--suspended")
-		}
-		if opts.GenerateKey != nil && *opts.GenerateKey {
-			args = append(args, "--gen-access-key", "--gen-secret")
-		}
 		if opts.AccessKey != "" {
 			args = append(args, "--access-key="+opts.AccessKey)
 		}


### PR DESCRIPTION
## Summary
- remove unused RGW user creation options that no longer need to be passed to the CLI
- update the RGW user creation helper to only append supported access and secret key flags

## Testing
- gofmt -w cli.go

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150a6159888326809b9909a47e261a)