### PR TITLE
Remove RGW subuser secret key options

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -250,10 +250,7 @@ type RgwUserModifyOptions struct {
 }
 
 type RgwSubuserCreateOptions struct {
-	Access         string
-	GenerateSecret *bool
-	SecretKey      string
-	KeyType        string
+	Access string
 }
 
 type RgwKeyCreateOptions struct {
@@ -397,15 +394,6 @@ func (c *CephCLI) RgwSubuserCreate(ctx context.Context, uid, subuser string, opt
 	if opts != nil {
 		if opts.Access != "" {
 			args = append(args, "--access="+opts.Access)
-		}
-		if opts.GenerateSecret != nil && *opts.GenerateSecret {
-			args = append(args, "--gen-secret")
-		}
-		if opts.SecretKey != "" {
-			args = append(args, "--secret-key="+opts.SecretKey)
-		}
-		if opts.KeyType != "" {
-			args = append(args, "--key-type="+opts.KeyType)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- drop secret generation fields from `RgwSubuserCreateOptions`
- stop appending the removed options when building the `radosgw-admin subuser create` command

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150a6de7d08326a7db3ce77273f126)