### PR TITLE
Remove RGW key auto-generation flags

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -257,11 +257,10 @@ type RgwSubuserCreateOptions struct {
 }
 
 type RgwKeyCreateOptions struct {
-	Subuser     string
-	KeyType     string
-	AccessKey   string
-	SecretKey   string
-	GenerateKey *bool
+	Subuser   string
+	KeyType   string
+	AccessKey string
+	SecretKey string
 }
 
 func (c *CephCLI) RgwUserCreate(ctx context.Context, uid, displayName string, opts *RgwUserCreateOptions) (*RgwUserInfo, error) {
@@ -438,9 +437,6 @@ func (c *CephCLI) RgwKeyCreate(ctx context.Context, uid string, opts *RgwKeyCrea
 		}
 		if opts.SecretKey != "" {
 			args = append(args, "--secret-key="+opts.SecretKey)
-		}
-		if opts.GenerateKey != nil && *opts.GenerateKey {
-			args = append(args, "--gen-access-key", "--gen-secret")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- drop the GenerateKey toggle from RgwKeyCreateOptions
- remove the corresponding CLI flag handling when creating RGW keys
- gofmt the CLI implementation

## Testing
- gofmt -w cli.go

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150a7420f48326a0f93f07b475e9be)