### PR TITLE
Remove unused RGW bucket removal helper

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -503,14 +503,3 @@ func (c *CephCLI) RgwBucketInfo(ctx context.Context, bucket string) (*RgwBucketI
 
 	return &bucketInfo, nil
 }
-
-func (c *CephCLI) RgwBucketRemove(ctx context.Context, bucket string) error {
-	args := []string{"--conf", c.confPath, "bucket", "rm", "--bucket=" + bucket, "--purge-objects"}
-
-	cmd := exec.CommandContext(ctx, "radosgw-admin", args...)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to remove rgw bucket %s: %w", bucket, err)
-	}
-
-	return nil
-}


### PR DESCRIPTION
## Summary
- remove the unused `CephCLI.RgwBucketRemove` helper to keep the CLI surface limited to active callers

## Testing
- `go test ./... -run TestDoesNotExist`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b8776713483268667b22ead189347)