### PR TITLE
Trim Ceph API cluster conf struct

### DIFF
--- a/api.go
+++ b/api.go
@@ -1155,21 +1155,8 @@ type CephAPIClusterConfValue struct {
 
 type CephAPIClusterConf struct {
 	Name               string                    `json:"name"`
-	Type               string                    `json:"type"`
 	Level              string                    `json:"level"`
-	Desc               string                    `json:"desc"`
-	LongDesc           string                    `json:"long_desc"`
-	Default            interface{}               `json:"default"`
-	DaemonDefault      interface{}               `json:"daemon_default"`
-	Min                interface{}               `json:"min"`
-	Max                interface{}               `json:"max"`
 	CanUpdateAtRuntime bool                      `json:"can_update_at_runtime"`
-	SeeAlso            []string                  `json:"see_also"`
-	EnumValues         []string                  `json:"enum_values"`
-	Tags               []string                  `json:"tags"`
-	Services           []string                  `json:"services"`
-	Flags              []string                  `json:"flags"`
-	Source             string                    `json:"source,omitempty"`
 	Value              []CephAPIClusterConfValue `json:"value,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- shrink the CephAPIClusterConf struct down to the fields used by the provider
- run gofmt to keep api.go formatted after the struct change

## Testing
- `go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b88b4f4e08326acf6d5c1c267bb01)