### PR TITLE
Remove ListErasureCodeProfiles helper

### DIFF
--- a/api.go
+++ b/api.go
@@ -2007,45 +2007,6 @@ type CephAPIErasureCodeProfile struct {
 	Directory          string `json:"directory,omitempty"`
 }
 
-func (c *CephAPIClient) ListErasureCodeProfiles(ctx context.Context) ([]CephAPIErasureCodeProfile, error) {
-	url := c.endpoint.JoinPath("/api/erasure_code_profile").String()
-
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Accept", "application/vnd.ceph.api.v1.0+json")
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.token)
-
-	logRequest := logAPIRequest(ctx, httpReq)
-	httpResp, err := c.client.Do(httpReq)
-	logRequest(httpResp, err)
-	if err != nil {
-		return nil, fmt.Errorf("unable to make request to Ceph API: %w", err)
-	}
-	defer httpResp.Body.Close() //nolint:errcheck
-
-	if httpResp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(httpResp.Body)
-		return nil, fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read response body: %w", err)
-	}
-
-	var profiles []CephAPIErasureCodeProfile
-	err = json.Unmarshal(body, &profiles)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode JSON response: %w", err)
-	}
-
-	return profiles, nil
-}
-
 // <https://docs.ceph.com/en/latest/mgr/ceph_api/#post--api-erasure_code_profile>
 
 type CephAPIErasureCodeProfileCreateRequest struct {


### PR DESCRIPTION
## Summary
- remove the unused `CephAPIClient.ListErasureCodeProfiles` helper so there are no lingering references
- run `go fmt ./...` to keep the tree formatted

## Testing
- `go fmt ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bcf6b8ccc8326a86b103aafe79d0c)