### PR TITLE
Remove unused Ceph cluster user listing API

### DIFF
--- a/api.go
+++ b/api.go
@@ -267,51 +267,6 @@ func (c *CephAPIClient) ClusterExportUser(ctx context.Context, entity string) (s
 	return keyringRaw, nil
 }
 
-// <https://docs.ceph.com/en/latest/mgr/ceph_api/#get--api-cluster-user>
-
-type CephAPIClusterUser struct {
-	Entity string            `json:"entity"`
-	Caps   map[string]string `json:"caps"`
-	Key    string            `json:"key"`
-}
-
-func (c *CephAPIClient) ClusterListUsers(ctx context.Context) ([]CephAPIClusterUser, error) {
-	url := c.endpoint.JoinPath("/api/cluster/user").String()
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Accept", "application/vnd.ceph.api.v1.0+json")
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.token)
-
-	logRequest := logAPIRequest(ctx, httpReq)
-	httpResp, err := c.client.Do(httpReq)
-	logRequest(httpResp, err)
-	if err != nil {
-		return nil, fmt.Errorf("unable to make request to Ceph API: %w", err)
-	}
-	defer httpResp.Body.Close() //nolint:errcheck
-
-	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("ceph API returned status %d", httpResp.StatusCode)
-	}
-
-	body, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read response body: %w", err)
-	}
-
-	var users []CephAPIClusterUser
-	err = json.Unmarshal(body, &users)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode JSON response: %w", err)
-	}
-
-	return users, nil
-}
-
 // <https://docs.ceph.com/en/latest/mgr/ceph_api/#post--api-cluster-user>
 
 type CephAPIClusterUserCapability struct {


### PR DESCRIPTION
## Summary
- remove the unused `CephAPIClusterUser` type and `CephAPIClient.ClusterListUsers` method from `api.go`
- run `go fmt ./...` to keep formatting tidy

## Testing
- `go fmt ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bcf570fa4832680f20c2dd6ecf98c)