### PR TITLE
Remove unused config dump fields

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -30,12 +30,10 @@ type CephAuthInfo struct {
 }
 
 type ConfigDumpEntry struct {
-	Section  string `json:"section"`
-	Mask     string `json:"mask"`
-	Name     string `json:"name"`
-	Value    string `json:"value"`
-	Level    string `json:"level"`
-	ReadOnly bool   `json:"readonly"`
+	Section string `json:"section"`
+	Mask    string `json:"mask"`
+	Name    string `json:"name"`
+	Value   string `json:"value"`
 }
 
 const floatComparisonEpsilon = 1e-9


### PR DESCRIPTION
## Summary
- remove the unused `Level` and `ReadOnly` members from `ConfigDumpEntry`
- run gofmt on `cli.go`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd6d98f288326b0c0bf54e74afeec)