### PR TITLE
Remove daemon name from RGW bucket request struct

### DIFF
--- a/api.go
+++ b/api.go
@@ -511,10 +511,9 @@ func (c *CephAPIClient) RGWGetBucket(ctx context.Context, bucketName string) (Ce
 }
 
 type CephAPIRGWBucketCreateRequest struct {
-	Bucket     string  `json:"bucket"`
-	UID        string  `json:"uid"`
-	Zonegroup  *string `json:"zonegroup,omitempty"`
-	DaemonName *string `json:"daemon_name,omitempty"`
+	Bucket    string  `json:"bucket"`
+	UID       string  `json:"uid"`
+	Zonegroup *string `json:"zonegroup,omitempty"`
 }
 
 func (c *CephAPIClient) RGWCreateBucket(ctx context.Context, req CephAPIRGWBucketCreateRequest) (CephAPIRGWBucket, error) {


### PR DESCRIPTION
## Summary
- remove the unused `DaemonName` field from `CephAPIRGWBucketCreateRequest`
- run `go fmt` on `api.go` to keep formatting consistent

## Testing
- `go test ./... -run TestDoesNotExist -vet=off`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd77b0498832697c89b96bee016a3)