### PR TITLE
Propagate test contexts in acceptance helpers

### DIFF
--- a/auth_resource_test.go
+++ b/auth_resource_test.go
@@ -315,7 +315,7 @@ func testAccCheckCephAuthDestroy(s *terraform.State) error {
 func checkCephAuthExists(t *testing.T, entity string) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		authInfo, err := cephTestClusterCLI.AuthGet(ctx, entity)
@@ -331,7 +331,7 @@ func checkCephAuthExists(t *testing.T, entity string) resource.TestCheckFunc {
 func checkCephAuthHasCaps(t *testing.T, entity string, expectedCaps map[string]string) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		authInfo, err := cephTestClusterCLI.AuthGet(ctx, entity)
@@ -356,7 +356,7 @@ func checkCephAuthHasCaps(t *testing.T, entity string, expectedCaps map[string]s
 func checkCephAuthHasKey(t *testing.T, entity string, expectedKey string) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		authInfo, err := cephTestClusterCLI.AuthGet(ctx, entity)
@@ -451,7 +451,7 @@ func TestAccCephAuthResource_capsDriftDetection(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 					defer cancel()
 
 					err := cephTestClusterCLI.AuthSetCaps(ctx, testEntity, map[string]string{

--- a/config_data_source_test.go
+++ b/config_data_source_test.go
@@ -76,7 +76,7 @@ func TestAccCephConfigDataSource_multiLevel(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.ConfigSet(ctx, "global", configName, fmt.Sprintf("%d", globalValue)); err != nil {
@@ -91,8 +91,9 @@ func TestAccCephConfigDataSource_multiLevel(t *testing.T) {
 				t.Fatalf("Failed to set osd.0 config: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.ConfigRemove(cleanupCtx, "global", configName)

--- a/config_value_data_source_test.go
+++ b/config_value_data_source_test.go
@@ -26,15 +26,16 @@ func TestAccCephConfigValueDataSource(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.ConfigSet(ctx, "global", configName, fmt.Sprintf("%d", testValue)); err != nil {
 				t.Fatalf("Failed to set test config: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.ConfigRemove(cleanupCtx, "global", configName)
@@ -95,7 +96,7 @@ func TestAccCephConfigValueDataSource_multipleSections(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.ConfigSet(ctx, "global", configName, fmt.Sprintf("%d", testValue1)); err != nil {
@@ -106,8 +107,9 @@ func TestAccCephConfigValueDataSource_multipleSections(t *testing.T) {
 				t.Fatalf("Failed to set test config for mon: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.ConfigRemove(cleanupCtx, "global", configName)
@@ -199,15 +201,16 @@ func TestAccCephConfigValueDataSource_readMaskedConfig(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.ConfigSet(ctx, "osd/class:ssd", configName, fmt.Sprintf("%d", testValue)); err != nil {
 				t.Fatalf("Failed to set masked config via CLI: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.ConfigRemove(cleanupCtx, "osd/class:ssd", configName)

--- a/crush_rule_data_source_test.go
+++ b/crush_rule_data_source_test.go
@@ -22,15 +22,16 @@ func TestAccCephCrushRuleDataSource_replicated(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck: func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.CrushRuleCreateReplicated(ctx, ruleName, "default", "host"); err != nil {
 				t.Fatalf("Failed to create replicated crush rule: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 30*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.CrushRuleRemove(cleanupCtx, ruleName)
@@ -100,15 +101,16 @@ func TestAccCephCrushRuleDataSource_simple(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck: func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.CrushRuleCreateSimple(ctx, ruleName, "default", "host"); err != nil {
 				t.Fatalf("Failed to create simple crush rule: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 30*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.CrushRuleRemove(cleanupCtx, ruleName)
@@ -179,7 +181,7 @@ func TestAccCephCrushRuleDataSource_erasure(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck: func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.ErasureCodeProfileSet(ctx, profileName, map[string]string{
@@ -194,8 +196,9 @@ func TestAccCephCrushRuleDataSource_erasure(t *testing.T) {
 				t.Fatalf("Failed to create erasure crush rule: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 30*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.CrushRuleRemove(cleanupCtx, ruleName)

--- a/erasure_code_profile_data_source_test.go
+++ b/erasure_code_profile_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccCephErasureCodeProfileDataSource_k2m1(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck: func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.ErasureCodeProfileSet(ctx, profileName, map[string]string{
@@ -33,8 +33,9 @@ func TestAccCephErasureCodeProfileDataSource_k2m1(t *testing.T) {
 				t.Fatalf("Failed to create erasure code profile: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 30*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.ErasureCodeProfileRemove(cleanupCtx, profileName)
@@ -89,7 +90,7 @@ func TestAccCephErasureCodeProfileDataSource_k3m2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck: func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.ErasureCodeProfileSet(ctx, profileName, map[string]string{
@@ -100,8 +101,9 @@ func TestAccCephErasureCodeProfileDataSource_k3m2(t *testing.T) {
 				t.Fatalf("Failed to create erasure code profile: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 30*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.ErasureCodeProfileRemove(cleanupCtx, profileName)

--- a/pool_data_source_test.go
+++ b/pool_data_source_test.go
@@ -22,15 +22,16 @@ func TestAccCephPoolDataSource(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 8, ""); err != nil {
 				t.Fatalf("Failed to create pool: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)
@@ -91,15 +92,16 @@ func TestAccCephPoolDataSource_erasureCoded(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 8, "erasure"); err != nil {
 				t.Fatalf("Failed to create erasure coded pool: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)
@@ -149,7 +151,7 @@ func TestAccCephPoolDataSource_withApplication(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 8, ""); err != nil {
@@ -160,8 +162,9 @@ func TestAccCephPoolDataSource_withApplication(t *testing.T) {
 				t.Fatalf("Failed to enable application: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)
@@ -212,7 +215,7 @@ func TestAccCephPoolDataSource_compression(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 8, ""); err != nil {
@@ -231,8 +234,9 @@ func TestAccCephPoolDataSource_compression(t *testing.T) {
 				t.Fatalf("Failed to set compression required ratio: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)
@@ -288,15 +292,16 @@ func TestAccCephPoolDataSource_configurationChanges(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 8, ""); err != nil {
 				t.Fatalf("Failed to create pool: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)
@@ -330,7 +335,7 @@ func TestAccCephPoolDataSource_configurationChanges(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+					ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
 					defer cancel()
 
 					if err := cephTestClusterCLI.PoolSet(ctx, poolName, "pg_num", "16"); err != nil {
@@ -380,15 +385,16 @@ func TestAccCephPoolDataSource_customPGCount(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 32, ""); err != nil {
 				t.Fatalf("Failed to create pool: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)
@@ -435,7 +441,7 @@ func TestAccCephPoolDataSource_targetSize(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 8, ""); err != nil {
@@ -450,8 +456,9 @@ func TestAccCephPoolDataSource_targetSize(t *testing.T) {
 				t.Fatalf("Failed to set target size bytes: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)
@@ -502,7 +509,7 @@ func TestAccCephPoolDataSource_autoscaler(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 8, ""); err != nil {
@@ -513,8 +520,9 @@ func TestAccCephPoolDataSource_autoscaler(t *testing.T) {
 				t.Fatalf("Failed to set autoscale mode: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)
@@ -560,7 +568,7 @@ func TestAccCephPoolDataSource_configuration(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckCephHealth(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			if err := cephTestClusterCLI.PoolCreate(ctx, poolName, 8, ""); err != nil {
@@ -571,8 +579,9 @@ func TestAccCephPoolDataSource_configuration(t *testing.T) {
 				t.Fatalf("Failed to set noscrub flag: %v", err)
 			}
 
+			cleanupCtxParent := t.Context()
 			t.Cleanup(func() {
-				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 				defer cleanupCancel()
 
 				_ = cephTestClusterCLI.PoolDelete(cleanupCtx, poolName)

--- a/provider_test.go
+++ b/provider_test.go
@@ -821,7 +821,7 @@ func TestAccProvider_tokenAuthentication(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck: func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			client := &CephAPIClient{}

--- a/rgw_bucket_resource_test.go
+++ b/rgw_bucket_resource_test.go
@@ -159,7 +159,7 @@ func testAccCheckCephRGWBucketDestroy(s *terraform.State) error {
 func checkCephRGWBucketExists(t *testing.T, bucketName string) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 
 		bucket, err := cephTestClusterCLI.RgwBucketInfo(ctx, bucketName)

--- a/rgw_s3_key_data_source_test.go
+++ b/rgw_s3_key_data_source_test.go
@@ -186,7 +186,7 @@ func TestAccCephRGWS3KeyDataSource_multipleKeys(t *testing.T) {
 func createTestRGWUserWithCustomS3Key(t *testing.T, uid, displayName, accessKey, secretKey string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	_ = cephTestClusterCLI.RgwUserRemove(ctx, uid, true)
@@ -201,8 +201,9 @@ func createTestRGWUserWithCustomS3Key(t *testing.T, uid, displayName, accessKey,
 
 	t.Logf("Created test RGW user: %s with custom S3 key: %s", uid, accessKey)
 
+	cleanupCtxParent := t.Context()
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 		defer cleanupCancel()
 
 		if err := cephTestClusterCLI.RgwUserRemove(cleanupCtx, uid, true); err != nil {
@@ -216,7 +217,7 @@ func createTestRGWUserWithCustomS3Key(t *testing.T, uid, displayName, accessKey,
 func createTestRGWUserWithSubuserAndS3Keys(t *testing.T, uid, displayName, subuser, parentAccessKey, parentSecretKey, subuserAccessKey, subuserSecretKey string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	_ = cephTestClusterCLI.RgwUserRemove(ctx, uid, true)
@@ -248,8 +249,9 @@ func createTestRGWUserWithSubuserAndS3Keys(t *testing.T, uid, displayName, subus
 
 	t.Logf("Created test RGW user: %s with subuser: %s and S3 keys", uid, subuser)
 
+	cleanupCtxParent := t.Context()
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 		defer cleanupCancel()
 
 		if err := cephTestClusterCLI.RgwUserRemove(cleanupCtx, uid, true); err != nil {
@@ -263,7 +265,7 @@ func createTestRGWUserWithSubuserAndS3Keys(t *testing.T, uid, displayName, subus
 func createTestRGWUserWithMultipleS3Keys(t *testing.T, uid, displayName, accessKey1, secretKey1, accessKey2, secretKey2 string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	_ = cephTestClusterCLI.RgwUserRemove(ctx, uid, true)
@@ -287,8 +289,9 @@ func createTestRGWUserWithMultipleS3Keys(t *testing.T, uid, displayName, accessK
 
 	t.Logf("Created test RGW user: %s with multiple S3 keys", uid)
 
+	cleanupCtxParent := t.Context()
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 		defer cleanupCancel()
 
 		if err := cephTestClusterCLI.RgwUserRemove(cleanupCtx, uid, true); err != nil {
@@ -302,7 +305,7 @@ func createTestRGWUserWithMultipleS3Keys(t *testing.T, uid, displayName, accessK
 func createTestRGWUserWithoutKeys(t *testing.T, uid, displayName string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	err := cephTestClusterCLI.RgwUserCreate(ctx, uid, displayName, nil)
@@ -324,8 +327,9 @@ func createTestRGWUserWithoutKeys(t *testing.T, uid, displayName string) {
 
 	t.Logf("Created test RGW user without keys: %s", uid)
 
+	cleanupCtxParent := t.Context()
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 		defer cleanupCancel()
 
 		if err := cephTestClusterCLI.RgwUserRemove(cleanupCtx, uid, true); err != nil {
@@ -351,7 +355,7 @@ func TestAccCephRGWS3KeyDataSource_ambiguousResults(t *testing.T) {
 		PreCheck: func() {
 			createTestRGWUserWithoutKeys(t, testUID, "Test Ambiguous S3 Key User")
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			err := cephTestClusterCLI.RgwKeyCreate(ctx, testUID, &RgwKeyCreateOptions{

--- a/rgw_s3_key_resource_test.go
+++ b/rgw_s3_key_resource_test.go
@@ -186,7 +186,7 @@ func TestAccCephRGWS3KeyResource_nonExistentUser(t *testing.T) {
 func createTestRGWUserWithSubuserWithoutKeys(t *testing.T, uid, displayName, subuser string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	err := cephTestClusterCLI.RgwUserCreate(ctx, uid, displayName, nil)
@@ -203,8 +203,9 @@ func createTestRGWUserWithSubuserWithoutKeys(t *testing.T, uid, displayName, sub
 
 	t.Logf("Created test RGW user: %s with subuser: %s", uid, subuser)
 
+	cleanupCtxParent := t.Context()
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 		defer cleanupCancel()
 
 		if err := cephTestClusterCLI.RgwUserRemove(cleanupCtx, uid, true); err != nil {
@@ -518,7 +519,7 @@ func TestAccCephRGWS3KeyResource_importMultipleKeysManagement(t *testing.T) {
 func createRGWS3Key(t *testing.T, userID, accessKey, secretKey string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	err := cephTestClusterCLI.RgwKeyCreate(ctx, userID, &RgwKeyCreateOptions{

--- a/rgw_subuser_data_source_test.go
+++ b/rgw_subuser_data_source_test.go
@@ -86,7 +86,7 @@ func TestAccCephRGWSubuserDataSource_invalidFormat(t *testing.T) {
 func createTestRGWUserWithSubuser(t *testing.T, uid, displayName, subuser, permissions string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	_ = cephTestClusterCLI.RgwUserRemove(ctx, uid, true)
@@ -105,8 +105,9 @@ func createTestRGWUserWithSubuser(t *testing.T, uid, displayName, subuser, permi
 
 	t.Logf("Created test RGW user: %s with subuser: %s", uid, subuser)
 
+	cleanupCtxParent := t.Context()
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 		defer cleanupCancel()
 
 		if err := cephTestClusterCLI.RgwUserRemove(cleanupCtx, uid, true); err != nil {

--- a/rgw_user_data_source_test.go
+++ b/rgw_user_data_source_test.go
@@ -91,7 +91,7 @@ func TestAccCephRGWUserDataSource_adminFlagOutOfBand(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 					defer cancel()
 
 					admin := true
@@ -117,7 +117,7 @@ func TestAccCephRGWUserDataSource_adminFlagOutOfBand(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 					defer cancel()
 
 					admin := false
@@ -171,7 +171,7 @@ func TestAccCephRGWUserDataSource_deletedOutOfBand(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 					defer cancel()
 
 					if err := cephTestClusterCLI.RgwUserRemove(ctx, testUID, true); err != nil {
@@ -194,7 +194,7 @@ func TestAccCephRGWUserDataSource_deletedOutOfBand(t *testing.T) {
 func createTestRGWUser(t *testing.T, uid, displayName string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	err := cephTestClusterCLI.RgwUserCreate(ctx, uid, displayName, nil)
@@ -204,8 +204,9 @@ func createTestRGWUser(t *testing.T, uid, displayName string) {
 
 	t.Logf("Created test RGW user: %s", uid)
 
+	cleanupCtxParent := t.Context()
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 		defer cleanupCancel()
 
 		if err := cephTestClusterCLI.RgwUserRemove(cleanupCtx, uid, true); err != nil {

--- a/rgw_user_resource_test.go
+++ b/rgw_user_resource_test.go
@@ -408,7 +408,7 @@ func testAccCheckCephRGWUserDestroy(s *terraform.State) error {
 func checkCephRGWUserExists(t *testing.T, userID string) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 
 		user, err := cephTestClusterCLI.RgwUserInfo(ctx, userID)
@@ -485,7 +485,7 @@ func TestAccCephRGWUserResource_managedS3Keys(t *testing.T) {
 func checkCephRGWUserKeyCount(t *testing.T, userID string, expectedCount int) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 
 		userInfo, err := cephTestClusterCLI.RgwUserInfo(ctx, userID)
@@ -533,7 +533,7 @@ func TestAccCephRGWUserResource_alreadyExists(t *testing.T) {
 func createTestRGWUserDirectly(t *testing.T, uid, displayName string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	err := cephTestClusterCLI.RgwUserCreate(ctx, uid, displayName, nil)
@@ -543,8 +543,9 @@ func createTestRGWUserDirectly(t *testing.T, uid, displayName string) {
 
 	t.Logf("Pre-created test RGW user: %s", uid)
 
+	cleanupCtxParent := t.Context()
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cleanupCancel := context.WithTimeout(cleanupCtxParent, 10*time.Second)
 		defer cleanupCancel()
 
 		if err := cephTestClusterCLI.RgwUserRemove(cleanupCtx, uid, true); err != nil {
@@ -669,7 +670,7 @@ func TestAccCephRGWUserResource_suspendUnsuspendCycle(t *testing.T) {
 func checkCephRGWUserSuspended(t *testing.T, userID string, expectedSuspended bool) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 
 		userInfo, err := cephTestClusterCLI.RgwUserInfo(ctx, userID)
@@ -792,7 +793,7 @@ func TestAccCephRGWUserResource_emailUpdate(t *testing.T) {
 func checkCephRGWUserEmail(t *testing.T, userID string, expectedEmail string) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 
 		userInfo, err := cephTestClusterCLI.RgwUserInfo(ctx, userID)
@@ -892,7 +893,7 @@ func TestAccCephRGWUserResource_maxBucketsValidation(t *testing.T) {
 func checkCephRGWUserMaxBuckets(t *testing.T, userID string, expectedMaxBuckets int) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 
 		userInfo, err := cephTestClusterCLI.RgwUserInfo(ctx, userID)
@@ -958,7 +959,7 @@ func TestAccCephRGWUserResource_suspendOutOfBand(t *testing.T) {
 func suspendUserViaCLI(t *testing.T, userID string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	if err := cephTestClusterCLI.RgwUserSuspend(ctx, userID, true); err != nil {
@@ -993,7 +994,7 @@ func TestAccCephRGWUserResource_driftDetection(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 					defer cancel()
 
 					maxBuckets := 200


### PR DESCRIPTION
## Summary
- derive contexts from `t.Context()` in acceptance test PreChecks and helper cleanups so CLI calls respect parent cancellations
- ensure helper routines such as RGW user/key fixtures and provider token setup share the updated contexts

## Testing
- `go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd6cb9ab08326bbbe6a8669e88b8f)