### PR TITLE
Remove unused PoolList helper

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -886,21 +886,6 @@ func (c *CephCLI) CheckHealth(ctx context.Context) error {
 	return nil
 }
 
-func (c *CephCLI) PoolList(ctx context.Context) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "ceph", "--conf", c.confPath, "osd", "pool", "ls", "--format", "json")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list pools: %w", err)
-	}
-
-	var pools []string
-	if err := json.Unmarshal(output, &pools); err != nil {
-		return nil, fmt.Errorf("failed to parse pool list: %w", err)
-	}
-
-	return pools, nil
-}
-
 func (c *CephCLI) ConfigDump(ctx context.Context) ([]ConfigDumpEntry, error) {
 	cmd := exec.CommandContext(ctx, "ceph", "--conf", c.confPath, "config", "dump", "--format", "json")
 	output, err := cmd.Output()


### PR DESCRIPTION
## Summary
- remove the unused PoolList helper from the CLI client to reduce dead code

## Testing
- go test ./... (interrupted after extended dependency download)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920fc30d8948326891c1f05d4df40af)