### PR TITLE
Switch Dependabot merge workflow to ubuntu-slim runner

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.actor == 'dependabot[bot]' && github.repository == 'josh/terraform-provider-ceph'
 
     steps:


### PR DESCRIPTION
## Summary
- switch the Dependabot auto-merge workflow to the ubuntu-slim runner

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692366dd888083268689adcec0bafe71)