### PR TITLE
Remove rgw_s3_key from state when parent user is gone

### DIFF
--- a/rgw_s3_key_resource.go
+++ b/rgw_s3_key_resource.go
@@ -237,6 +237,10 @@ func (r *RGWS3KeyResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	user, err := r.client.RGWGetUser(ctx, parentUID)
 	if err != nil {
+		if errors.Is(err, ErrAPINotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"API Request Error",
 			fmt.Sprintf("Unable to read RGW user: %s", err),


### PR DESCRIPTION
Read returned a hard error when the owning RGW user had been deleted out-of-band, permanently wedging refresh/plan. Treat ErrAPINotFound like a deleted key and remove the resource from state so Terraform can plan recreation.