### PR TITLE
Fail rgw_s3_key create when the pre-create key snapshot fails

### DIFF
--- a/rgw_s3_key_resource.go
+++ b/rgw_s3_key_resource.go
@@ -154,7 +154,14 @@ func (r *RGWS3KeyResource) Create(ctx context.Context, req resource.CreateReques
 	existingKeys := make(map[string]bool)
 	if accessKeyPtr == nil {
 		user, err := r.client.RGWGetUser(ctx, parentUID)
-		if err == nil {
+		if err != nil && !errors.Is(err, ErrAPINotFound) {
+			resp.Diagnostics.AddError(
+				"API Request Error",
+				fmt.Sprintf("Unable to read RGW user before key creation: %s", err),
+			)
+			return
+		}
+		if user != nil {
 			for _, key := range user.Keys {
 				if key.User == userID {
 					existingKeys[key.AccessKey] = true


### PR DESCRIPTION
When auto-generating a key, Create snapshots the user's existing keys to identify the new one afterwards. A transient error on that snapshot was silently ignored, leaving the snapshot empty so the matcher could adopt a pre-existing key's access/secret into state and orphan the key that was actually created. Surface the error instead (a missing user still proceeds and fails on the create call itself).