### PR TITLE
Clear rgw_user email when the attribute is removed from config

### DIFF
--- a/rgw_user_resource.go
+++ b/rgw_user_resource.go
@@ -188,8 +188,10 @@ func (r *RGWUserResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 func (r *RGWUserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data RGWUserResourceModel
+	var state RGWUserResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -205,6 +207,9 @@ func (r *RGWUserResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	if !data.Email.IsNull() && !data.Email.IsUnknown() {
 		email := data.Email.ValueString()
+		updateReq.Email = &email
+	} else if data.Email.IsNull() && !state.Email.IsNull() {
+		email := ""
 		updateReq.Email = &email
 	}
 


### PR DESCRIPTION
Removing email from an existing user's config planned it as null, but Update omitted the field entirely so the server kept the old address, which the read-back then wrote into state - failing every apply with "Provider produced inconsistent result after apply". Send an empty email when the plan transitions a previously-set email to null so the server value is actually cleared and state matches the plan.