### PR TITLE
Handle null MGR module config values

### DIFF
--- a/mgr_module_config_data_source.go
+++ b/mgr_module_config_data_source.go
@@ -118,6 +118,8 @@ func (d *MgrModuleConfigDataSource) Read(ctx context.Context, req datasource.Rea
 
 func formatMgrModuleConfigValue(val any) (string, error) {
 	switch v := val.(type) {
+	case nil:
+		return "", nil
 	case float64:
 		if v == float64(int64(v)) {
 			return fmt.Sprintf("%d", int64(v)), nil


### PR DESCRIPTION
The dashboard returns JSON null for module options whose default is Python None (e.g. cephadm's migration_current), and formatMgrModuleConfigValue had no nil case - so reading such a module via the data source, resource Read, or import failed hard with "unsupported config value type: <nil>". Format null as an empty string.