### PR TITLE
Mask cephx keys in ClusterImportUser trace logging

### DIFF
--- a/api.go
+++ b/api.go
@@ -497,6 +497,14 @@ func (c *CephAPIClient) ClusterImportUser(ctx context.Context, importData string
 		return fmt.Errorf("unable to encode request payload: %w", err)
 	}
 
+	if users, err := parseCephKeyring(importData); err == nil {
+		for _, user := range users {
+			if user.Key != "" {
+				ctx = tflog.MaskLogStrings(ctx, user.Key)
+			}
+		}
+	}
+
 	tflog.Trace(ctx, "Ceph API request body", map[string]any{
 		"request_body": string(jsonPayload),
 	})


### PR DESCRIPTION
The import request body contains the plaintext cephx key when a ceph_auth resource specifies one, and it was trace-logged unmasked - unlike Auth (masks the password) and ClusterExportUser (masks exported keys). Mask every key in the import payload before logging so TF_LOG=TRACE runs don't leak credentials.