### PR TITLE
Strip only the surrounding quote pair when parsing keyring caps

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -99,7 +99,10 @@ func parseCephKeyring(content string) ([]CephUser, error) {
 				cur.Key = strings.TrimSpace(matches[1])
 			} else if matches := capsRegex.FindStringSubmatch(line); matches != nil {
 				capType := matches[1]
-				capsValue := strings.Trim(strings.TrimSpace(matches[2]), `"`)
+				capsValue := strings.TrimSpace(matches[2])
+				if len(capsValue) >= 2 && strings.HasPrefix(capsValue, `"`) && strings.HasSuffix(capsValue, `"`) {
+					capsValue = capsValue[1 : len(capsValue)-1]
+				}
 
 				lower := strings.ToLower(capType)
 				switch lower {

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -102,6 +102,30 @@ func TestParseClientFooKeyring(t *testing.T) {
 	}
 }
 
+func TestParseQuotedCommandCapsKeyring(t *testing.T) {
+	text := `[client.foo]
+	key = AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+	caps mon = "allow command "osd blacklist""
+`
+
+	expected := []CephUser{
+		{
+			Entity: "client.foo",
+			Key:    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+			Caps:   MustCephCapsFromMap(map[string]string{"mon": `allow command "osd blacklist"`}),
+		},
+	}
+
+	actual, err := parseCephKeyring(text)
+	if err != nil {
+		t.Errorf("parseCephKeyring() error = %v, wantErr nil", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("parseCephKeyring() = %v, want %v", actual, expected)
+	}
+}
+
 func TestParseNoCapsKeyring(t *testing.T) {
 	text := `[client.foo]
 	key = AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==`


### PR DESCRIPTION
Ceph prints caps unescaped inside a single pair of quotes, so a cap like allow command "osd blacklist" exports with nested quotes. strings.Trim removed every leading/trailing quote, corrupting the value and causing inconsistent-result errors on apply plus perpetual drift. Strip exactly one surrounding pair instead.