### PR TITLE
Reject empty ceph_config values at plan time

### DIFF
--- a/config_resource.go
+++ b/config_resource.go
@@ -53,6 +53,7 @@ func (r *ConfigResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				ElementType:         types.StringType,
 				Validators: []validator.Map{
 					NoMgrPrefixKeys(),
+					NoEmptyValues(),
 				},
 			},
 		},

--- a/config_validators.go
+++ b/config_validators.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type noMgrPrefixKeysValidator struct{}
@@ -37,4 +38,38 @@ func (v noMgrPrefixKeysValidator) ValidateMap(ctx context.Context, req validator
 
 func NoMgrPrefixKeys() validator.Map {
 	return noMgrPrefixKeysValidator{}
+}
+
+type noEmptyValuesValidator struct{}
+
+func (v noEmptyValuesValidator) Description(ctx context.Context) string {
+	return "ensures no map values are empty strings"
+}
+
+func (v noEmptyValuesValidator) MarkdownDescription(ctx context.Context) string {
+	return "Ensures no map values are empty strings."
+}
+
+func (v noEmptyValuesValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	for key, value := range req.ConfigValue.Elements() {
+		str, ok := value.(types.String)
+		if !ok || str.IsUnknown() || str.IsNull() {
+			continue
+		}
+		if str.ValueString() == "" {
+			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+				req.Path,
+				"Invalid Configuration Value",
+				fmt.Sprintf("Configuration '%s' cannot be an empty string. The Ceph dashboard treats an empty value as a removal; omit the key instead.", key),
+			))
+		}
+	}
+}
+
+func NoEmptyValues() validator.Map {
+	return noEmptyValuesValidator{}
 }


### PR DESCRIPTION
The dashboard's cluster_conf create endpoint runs config rm when the submitted value is an empty string, so config = { opt = "" } silently deleted the option instead of setting it, and the following Read found nothing - removing the resource from state and recreating it on every apply, forever. Reject empty values with a validator.