### PR TITLE
Validate ceph_auth caps keys at plan time

### DIFF
--- a/auth_ephemeral_resource.go
+++ b/auth_ephemeral_resource.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -47,6 +50,9 @@ func (r *AuthEphemeralResource) Schema(ctx context.Context, req ephemeral.Schema
 				ElementType:         types.StringType,
 				MarkdownDescription: "The caps of the entity",
 				Required:            true,
+				Validators: []validator.Map{
+					mapvalidator.KeysAre(stringvalidator.OneOf("mds", "mgr", "mon", "osd")),
+				},
 			},
 			"key": schema.StringAttribute{
 				MarkdownDescription: "The generated cephx key of the entity.",

--- a/auth_resource.go
+++ b/auth_resource.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -53,6 +56,9 @@ func (r *AuthResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				ElementType:         types.StringType,
 				MarkdownDescription: "The caps of the entity",
 				Required:            true,
+				Validators: []validator.Map{
+					mapvalidator.KeysAre(stringvalidator.OneOf("mds", "mgr", "mon", "osd")),
+				},
 			},
 			"key": resourceSchema.StringAttribute{
 				MarkdownDescription: "The cephx key of the entity. If not specified, Ceph will generate a random key.",

--- a/auth_resource_test.go
+++ b/auth_resource_test.go
@@ -177,7 +177,7 @@ func TestAccCephAuthResource_invalidCapType(t *testing.T) {
 					  }
 					}
 				`, testEntity),
-				ExpectError: regexp.MustCompile(`(?i)caps attribute contains unsupported capability type`),
+				ExpectError: regexp.MustCompile(`(?i)invalid attribute value match`),
 			},
 		},
 	})
@@ -215,7 +215,22 @@ func TestAccCephAuthResource_invalidCapTypeOnUpdate(t *testing.T) {
 					  }
 					}
 				`, testEntity),
-				ExpectError: regexp.MustCompile(`(?i)caps attribute contains unsupported capability type`),
+				ExpectError: regexp.MustCompile(`(?i)invalid attribute value match`),
+			},
+			// Restore a valid config so the post-test destroy can plan;
+			// the validator now rejects the invalid config at plan time,
+			// which would otherwise fail the destroy as well.
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_auth" "test_update" {
+					  entity = %q
+					  caps = {
+					    mon = "allow r"
+					    osd = "allow rw pool=test"
+					  }
+					}
+				`, testEntity),
 			},
 		},
 	})


### PR DESCRIPTION
Caps map keys like MON were accepted at apply time, lowercased when sent to Ceph, and read back as mon - so state keys differed from the planned map and the apply failed with an inconsistent-result error. Reject anything but mds/mgr/mon/osd during validation on both the resource and the ephemeral resource.