### PR TITLE
Cover rejection of empty ceph_config values

### DIFF
--- a/config_resource_test.go
+++ b/config_resource_test.go
@@ -1102,3 +1102,26 @@ func testAccCheckCephConfigDestroy(t *testing.T) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+func TestAccCephConfigResource_emptyValueRejected(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + `
+					resource "ceph_config" "test" {
+						section = "global"
+						config = {
+							"mon_max_pg_per_osd" = ""
+						}
+					}
+				`,
+				ExpectError: regexp.MustCompile(`(?i)cannot be an empty string`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Regression test for the fix in #238: an empty value made the dashboard delete the option instead of setting it, causing a perpetual create/remove loop. The validator now rejects it at plan time.