### PR TITLE
Apply ceph_auth key changes via keyring import

### DIFF
--- a/auth_resource.go
+++ b/auth_resource.go
@@ -167,8 +167,10 @@ func (r *AuthResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 func (r *AuthResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data AuthResourceModel
+	var state AuthResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -181,7 +183,22 @@ func (r *AuthResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	err := r.client.ClusterUpdateUser(ctx, entity, caps)
+	var err error
+	key := data.Key.ValueString()
+	if !data.Key.IsNull() && !data.Key.IsUnknown() && key != "" && key != state.Key.ValueString() {
+		// ceph auth import replaces both the key and the caps of an
+		// existing entity; a plain caps update can never change the key.
+		users := []CephUser{
+			{
+				Entity: entity,
+				Key:    key,
+				Caps:   caps,
+			},
+		}
+		err = r.client.ClusterImportUser(ctx, formatCephKeyring(users))
+	} else {
+		err = r.client.ClusterUpdateUser(ctx, entity, caps)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Request Error",

--- a/auth_resource_test.go
+++ b/auth_resource_test.go
@@ -411,6 +411,67 @@ func TestAccCephAuthResource_staticKey(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCephAuthResource_keyUpdate(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	testEntity := acctest.RandomWithPrefix("client.test-key-update")
+	oldKey := "AQBvaBVesCMcKRAAoKhLdz8Qh/qPNqF9UGKYfg=="
+	newKey := "AQBvaBVesCMcKRAAbbbbdz8Qh/qPNqF9UGKYfg=="
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephAuthDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_auth" "foo" {
+					  entity = %q
+					  key    = %q
+					  caps = {
+					    mon = "allow r"
+					  }
+					}
+				`, testEntity, oldKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkCephAuthExists(t, testEntity),
+					checkCephAuthHasKey(t, testEntity, oldKey),
+				),
+			},
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_auth" "foo" {
+					  entity = %q
+					  key    = %q
+					  caps = {
+					    mon = "allow r"
+					  }
+					}
+				`, testEntity, newKey),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ceph_auth.foo", plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ceph_auth.foo",
+						tfjsonpath.New("key"),
+						knownvalue.StringExact(newKey),
+					),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkCephAuthExists(t, testEntity),
+					checkCephAuthHasKey(t, testEntity, newKey),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCephAuthResource_capsDriftDetection(t *testing.T) {
 	detachLogs := cephDaemonLogs.AttachTestFunction(t)
 	defer detachLogs()


### PR DESCRIPTION
Update only ever sent capabilities, so changing the key attribute left Ceph holding the old key while the read-back wrote that old key over the planned value - every key change failed with "Provider produced inconsistent result after apply" and there was no path that could ever install the new key. When the planned key differs from state, import a keyring for the entity instead, which updates key and caps together.