### PR TITLE
Skip subvolume group resize when no size is set

### DIFF
--- a/cephfs_subvolume_group_resource.go
+++ b/cephfs_subvolume_group_resource.go
@@ -222,21 +222,23 @@ func (r *CephFSSubvolumeGroupResource) Update(ctx context.Context, req resource.
 		"group_name": data.Name.ValueString(),
 	})
 
-	updateReq := CephAPISubvolumeGroupUpdateRequest{
-		GroupName: data.Name.ValueString(),
-	}
-
+	// The dashboard's subvolume group PUT requires a size argument, so only
+	// call it when there is a quota to apply; other updates (e.g. timeouts)
+	// have nothing to change on the Ceph side.
 	if !data.Size.IsNull() && !data.Size.IsUnknown() {
-		updateReq.Size = data.Size.ValueInt64()
-	}
+		updateReq := CephAPISubvolumeGroupUpdateRequest{
+			GroupName: data.Name.ValueString(),
+			Size:      data.Size.ValueInt64(),
+		}
 
-	err := r.client.CephFSSubvolumeGroupUpdate(ctx, data.VolName.ValueString(), updateReq)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"API Request Error",
-			fmt.Sprintf("Unable to update CephFS subvolume group '%s' in '%s': %s", data.Name.ValueString(), data.VolName.ValueString(), err),
-		)
-		return
+		err := r.client.CephFSSubvolumeGroupUpdate(ctx, data.VolName.ValueString(), updateReq)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"API Request Error",
+				fmt.Sprintf("Unable to update CephFS subvolume group '%s' in '%s': %s", data.Name.ValueString(), data.VolName.ValueString(), err),
+			)
+			return
+		}
 	}
 
 	info, err := r.client.CephFSSubvolumeGroupInfo(ctx, data.VolName.ValueString(), data.Name.ValueString())

--- a/cephfs_subvolume_group_resource_test.go
+++ b/cephfs_subvolume_group_resource_test.go
@@ -279,3 +279,52 @@ func TestAccCephFSSubvolumeGroupResource_OutOfBandDeletion(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCephFSSubvolumeGroupResource_TimeoutsOnlyUpdate(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	fsName := testSharedCephFSName
+	groupName := acctest.RandomWithPrefix("test-group-touts")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephFSSubvolumeGroupDestroy(t, fsName),
+		PreCheck: func() {
+			testAccPreCheckWaitForTasks(t)
+			testAccPreCheckWaitForPGsActiveClean(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_cephfs_subvolume_group" "test" {
+					  name     = %q
+					  vol_name = %q
+					}
+				`, groupName, fsName),
+				Check: checkCephFSSubvolumeGroupExists(t, fsName, groupName),
+			},
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_cephfs_subvolume_group" "test" {
+					  name     = %q
+					  vol_name = %q
+
+					  timeouts = {
+					    create = "10m"
+					    delete = "10m"
+					  }
+					}
+				`, groupName, fsName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ceph_cephfs_subvolume_group.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: checkCephFSSubvolumeGroupExists(t, fsName, groupName),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Update always PUT the group, but omitted the size field when the plan had none (json omitempty also drops 0) - and the dashboard's subvolume group set endpoint has no default for size, so a timeouts-only update on a quota-less group always failed. Only call the resize endpoint when the plan carries a known size.