### PR TITLE
Error on unknown mgr_module_config keys instead of dropping them

### DIFF
--- a/mgr_module_config_resource.go
+++ b/mgr_module_config_resource.go
@@ -128,17 +128,26 @@ func (r *MgrModuleConfigResource) Create(ctx context.Context, req resource.Creat
 
 	stringConfigs := make(map[string]string)
 	for key := range configsMap {
-		if val, ok := readConfigs[key]; ok {
-			formattedVal, err := formatMgrModuleConfigValue(val)
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"Configuration Value Formatting Error",
-					fmt.Sprintf("Unable to format config value for key '%s': %s", key, err),
-				)
-				return
-			}
-			stringConfigs[key] = formattedVal
+		val, ok := readConfigs[key]
+		if !ok {
+			// The dashboard silently ignores unknown keys on set, so a
+			// missing key on read-back means the module never accepted it.
+			resp.Diagnostics.AddAttributeError(
+				path.Root("configs").AtMapKey(key),
+				"Unknown Configuration Option",
+				fmt.Sprintf("MGR module '%s' has no config option named '%s'.", moduleName, key),
+			)
+			return
 		}
+		formattedVal, err := formatMgrModuleConfigValue(val)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Configuration Value Formatting Error",
+				fmt.Sprintf("Unable to format config value for key '%s': %s", key, err),
+			)
+			return
+		}
+		stringConfigs[key] = formattedVal
 	}
 
 	configsValue, diags := types.MapValueFrom(ctx, types.StringType, stringConfigs)
@@ -279,17 +288,24 @@ func (r *MgrModuleConfigResource) Update(ctx context.Context, req resource.Updat
 
 	stringConfigs := make(map[string]string)
 	for key := range newConfigsMap {
-		if val, ok := readConfigs[key]; ok {
-			formattedVal, err := formatMgrModuleConfigValue(val)
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"Configuration Value Formatting Error",
-					fmt.Sprintf("Unable to format config value for key '%s': %s", key, err),
-				)
-				return
-			}
-			stringConfigs[key] = formattedVal
+		val, ok := readConfigs[key]
+		if !ok {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("configs").AtMapKey(key),
+				"Unknown Configuration Option",
+				fmt.Sprintf("MGR module '%s' has no config option named '%s'.", moduleName, key),
+			)
+			return
 		}
+		formattedVal, err := formatMgrModuleConfigValue(val)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Configuration Value Formatting Error",
+				fmt.Sprintf("Unable to format config value for key '%s': %s", key, err),
+			)
+			return
+		}
+		stringConfigs[key] = formattedVal
 	}
 
 	configsValue, diags := types.MapValueFrom(ctx, types.StringType, stringConfigs)

--- a/mgr_module_config_resource_test.go
+++ b/mgr_module_config_resource_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -765,6 +766,29 @@ func TestAccCephMgrModuleConfigResource_OutOfBandDeletion(t *testing.T) {
 					resource.TestCheckResourceAttr("ceph_mgr_module_config.test", "module_name", "dashboard"),
 					resource.TestCheckResourceAttr("ceph_mgr_module_config.test", "configs.standby_behaviour", "error"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccCephMgrModuleConfigResource_unknownKey(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + `
+					resource "ceph_mgr_module_config" "test" {
+						module_name = "dashboard"
+						configs = {
+							"no_such_option_xyz" = "1"
+						}
+					}
+				`,
+				ExpectError: regexp.MustCompile(`(?i)has no config option named`),
 			},
 		},
 	})


### PR DESCRIPTION
The dashboard's module set endpoint silently ignores config keys the module doesn't declare, and the read-back loop then omitted them from state - so a typo'd key surfaced as an opaque "inconsistent result after apply" framework error. Report the offending key with a clear attribute error on create and update instead.