### PR TITLE
Fix timeouts-only updates of cephfs subvolumes

### DIFF
--- a/cephfs_subvolume_resource.go
+++ b/cephfs_subvolume_resource.go
@@ -68,7 +68,11 @@ func (r *CephFSSubvolumeResource) Schema(ctx context.Context, req resource.Schem
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
+					// Not plain RequiresReplace: with no quota set the
+					// computed null is re-planned as unknown on any config
+					// change, which would force a replacement for e.g. a
+					// timeouts edit.
+					int64planmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 			"path": resourceSchema.StringAttribute{
@@ -216,7 +220,28 @@ func (r *CephFSSubvolumeResource) Read(ctx context.Context, req resource.ReadReq
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// All Ceph-side attributes require replacement, but Update still runs for
+// changes to the timeouts block and must produce a state matching the plan.
 func (r *CephFSSubvolumeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data CephFSSubvolumeResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	info, err := r.client.CephFSSubvolumeInfo(ctx, data.VolName.ValueString(), data.Name.ValueString(), "")
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"API Request Error",
+			fmt.Sprintf("Unable to read CephFS subvolume '%s' in '%s': %s", data.Name.ValueString(), data.VolName.ValueString(), err),
+		)
+		return
+	}
+
+	r.updateModelFromAPI(&data, info)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *CephFSSubvolumeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cephfs_subvolume_resource_test.go
+++ b/cephfs_subvolume_resource_test.go
@@ -299,3 +299,52 @@ func TestAccCephFSSubvolumeResource_OutOfBandDeletion(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCephFSSubvolumeResource_TimeoutsOnlyUpdate(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	fsName := testSharedCephFSName
+	subvolName := acctest.RandomWithPrefix("test-subvol-touts")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephFSSubvolumeDestroy(t, fsName),
+		PreCheck: func() {
+			testAccPreCheckWaitForTasks(t)
+			testAccPreCheckWaitForPGsActiveClean(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_cephfs_subvolume" "test" {
+					  name     = %q
+					  vol_name = %q
+					}
+				`, subvolName, fsName),
+				Check: checkCephFSSubvolumeExists(t, fsName, subvolName),
+			},
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_cephfs_subvolume" "test" {
+					  name     = %q
+					  vol_name = %q
+
+					  timeouts = {
+					    create = "10m"
+					    delete = "10m"
+					  }
+					}
+				`, subvolName, fsName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ceph_cephfs_subvolume.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: checkCephFSSubvolumeExists(t, fsName, subvolName),
+			},
+		},
+	})
+}


### PR DESCRIPTION
The empty Update left the framework's default response state (the prior state), so changing only the timeouts block failed with inconsistent result errors on timeouts and on the computed state attribute, which is planned unknown and was never filled in. Read the subvolume back and save the planned state.