### PR TITLE
Treat dashboard 400 does-not-exist errors as not found for cephfs

### DIFF
--- a/api.go
+++ b/api.go
@@ -2513,10 +2513,27 @@ func (c *CephAPIClient) CephFSDelete(ctx context.Context, name string) error {
 
 	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusAccepted && httpResp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(httpResp.Body)
+		if isCephFSNotFoundError(httpResp.StatusCode, body) {
+			return ErrAPINotFound
+		}
 		return fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
 	}
 
 	return nil
+}
+
+// The dashboard's cephfs controllers raise DashboardException (HTTP 400)
+// rather than returning 404 when a volume, subvolume, or group is missing;
+// the mgr/volumes error text always contains "does not exist".
+func isCephFSNotFoundError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+	dashboardErr, err := ParseCephDashboardError(body)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(dashboardErr.Detail, "does not exist")
 }
 
 type CephAPISubvolumeListEntry struct {
@@ -2649,6 +2666,9 @@ func (c *CephAPIClient) CephFSSubvolumeInfo(ctx context.Context, volName string,
 
 	if httpResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResp.Body)
+		if isCephFSNotFoundError(httpResp.StatusCode, body) {
+			return nil, ErrAPINotFound
+		}
 		return nil, fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
 	}
 
@@ -2739,6 +2759,9 @@ func (c *CephAPIClient) CephFSSubvolumeDelete(ctx context.Context, volName strin
 
 	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusAccepted && httpResp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(httpResp.Body)
+		if isCephFSNotFoundError(httpResp.StatusCode, body) {
+			return ErrAPINotFound
+		}
 		return fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
 	}
 
@@ -2786,6 +2809,9 @@ func (c *CephAPIClient) CephFSSubvolumeGroupInfo(ctx context.Context, volName st
 
 	if httpResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResp.Body)
+		if isCephFSNotFoundError(httpResp.StatusCode, body) {
+			return nil, ErrAPINotFound
+		}
 		return nil, fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
 	}
 
@@ -2909,6 +2935,9 @@ func (c *CephAPIClient) CephFSSubvolumeGroupDelete(ctx context.Context, volName 
 
 	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusAccepted && httpResp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(httpResp.Body)
+		if isCephFSNotFoundError(httpResp.StatusCode, body) {
+			return ErrAPINotFound
+		}
 		return fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
 	}
 

--- a/cephfs_subvolume_group_resource_test.go
+++ b/cephfs_subvolume_group_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
@@ -226,4 +227,55 @@ func testAccCheckCephFSSubvolumeGroupDestroy(t *testing.T, fsName string) resour
 
 		return nil
 	}
+}
+
+func TestAccCephFSSubvolumeGroupResource_OutOfBandDeletion(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	fsName := testSharedCephFSName
+	groupName := acctest.RandomWithPrefix("test-group-oob")
+
+	config := testAccProviderConfigBlock + fmt.Sprintf(`
+		resource "ceph_cephfs_subvolume_group" "test" {
+		  name     = %q
+		  vol_name = %q
+
+		  timeouts = {
+		    create = "5m"
+		    delete = "5m"
+		  }
+		}
+	`, groupName, fsName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephFSSubvolumeGroupDestroy(t, fsName),
+		PreCheck: func() {
+			testAccPreCheckWaitForTasks(t)
+			testAccPreCheckWaitForPGsActiveClean(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config:          config,
+				Check:           checkCephFSSubvolumeGroupExists(t, fsName, groupName),
+			},
+			{
+				PreConfig: func() {
+					if err := cephTestClusterCLI.CephFSSubvolumeGroupDelete(t.Context(), fsName, groupName); err != nil {
+						t.Fatalf("Failed to delete subvolume group out of band: %v", err)
+					}
+				},
+				ConfigVariables: testAccProviderConfig(),
+				Config:          config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ceph_cephfs_subvolume_group.test", plancheck.ResourceActionCreate),
+					},
+				},
+				Check: checkCephFSSubvolumeGroupExists(t, fsName, groupName),
+			},
+		},
+	})
 }

--- a/cephfs_subvolume_resource_test.go
+++ b/cephfs_subvolume_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
@@ -246,4 +247,55 @@ func testAccCheckCephFSSubvolumeDestroy(t *testing.T, fsName string) resource.Te
 
 		return nil
 	}
+}
+
+func TestAccCephFSSubvolumeResource_OutOfBandDeletion(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	fsName := testSharedCephFSName
+	subvolName := acctest.RandomWithPrefix("test-subvol-oob")
+
+	config := testAccProviderConfigBlock + fmt.Sprintf(`
+		resource "ceph_cephfs_subvolume" "test" {
+		  name     = %q
+		  vol_name = %q
+
+		  timeouts = {
+		    create = "5m"
+		    delete = "5m"
+		  }
+		}
+	`, subvolName, fsName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephFSSubvolumeDestroy(t, fsName),
+		PreCheck: func() {
+			testAccPreCheckWaitForTasks(t)
+			testAccPreCheckWaitForPGsActiveClean(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config:          config,
+				Check:           checkCephFSSubvolumeExists(t, fsName, subvolName),
+			},
+			{
+				PreConfig: func() {
+					if err := cephTestClusterCLI.CephFSSubvolumeDelete(t.Context(), fsName, subvolName); err != nil {
+						t.Fatalf("Failed to delete subvolume out of band: %v", err)
+					}
+				},
+				ConfigVariables: testAccProviderConfig(),
+				Config:          config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ceph_cephfs_subvolume.test", plancheck.ResourceActionCreate),
+					},
+				},
+				Check: checkCephFSSubvolumeExists(t, fsName, subvolName),
+			},
+		},
+	})
 }


### PR DESCRIPTION
The dashboard's cephfs controllers raise DashboardException (HTTP 400) instead of returning 404 when a filesystem, subvolume, or subvolume group is missing, so the existing 404 checks never fired: a resource deleted out-of-band made every subsequent refresh fail hard instead of removing it from state, and lenient-delete paths errored instead of succeeding. Map 400 responses whose detail says "does not exist" to ErrAPINotFound in the cephfs info and delete helpers.