### PR TITLE
Delete ephemeral auth entity when Open fails after creation

### DIFF
--- a/auth_ephemeral_resource.go
+++ b/auth_ephemeral_resource.go
@@ -105,6 +105,20 @@ func (r *AuthEphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequ
 		return
 	}
 
+	// The framework does not call Close after a failed Open, so delete the
+	// entity ourselves if anything below fails.
+	defer func() {
+		if !resp.Diagnostics.HasError() {
+			return
+		}
+		if err := r.client.ClusterDeleteUser(ctx, entity); err != nil && !errors.Is(err, ErrAPINotFound) {
+			resp.Diagnostics.AddWarning(
+				"Cleanup Failed",
+				fmt.Sprintf("Unable to delete user %q after failed open, it may need manual removal: %s", entity, err),
+			)
+		}
+	}()
+
 	entityJSON, err := json.Marshal(entity)
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
If the private-state write or the keyring export failed right after ClusterCreateUser succeeded, Open returned an error and the framework never calls Close for a failed Open - leaving a live credentialed auth entity orphaned in the cluster. Best-effort delete the entity when Open is about to fail after creating it.