### PR TITLE
Recover crush rule placement attributes on import

### DIFF
--- a/api.go
+++ b/api.go
@@ -1897,10 +1897,11 @@ func (c *CephAPIClient) UpdatePool(ctx context.Context, poolName string, req Cep
 // <https://docs.ceph.com/en/latest/mgr/ceph_api/#get--api-crush_rule>
 
 type CephAPICrushRuleStep struct {
-	Op   string `json:"op"`
-	Num  int    `json:"num"`
-	Type string `json:"type"`
-	Item int    `json:"item,omitempty"`
+	Op       string `json:"op"`
+	Num      int    `json:"num"`
+	Type     string `json:"type"`
+	Item     int    `json:"item,omitempty"`
+	ItemName string `json:"item_name,omitempty"`
 }
 
 type CephAPICrushRule struct {

--- a/crush_rule_resource.go
+++ b/crush_rule_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -337,6 +338,25 @@ func (r *CrushRuleResource) ImportState(ctx context.Context, req resource.Import
 	if diags := r.updateModelFromAPI(&data, rule); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
+	}
+
+	// failure_domain, root, and device_class are not part of the rule dump
+	// proper, but can be recovered from its steps; without them the first
+	// plan after import would force a replacement. The erasure profile is
+	// not recoverable and must be set in config to match.
+	for _, step := range rule.Steps {
+		switch {
+		case step.Op == "take" && step.ItemName != "":
+			root, deviceClass, hasClass := strings.Cut(step.ItemName, "~")
+			data.Root = types.StringValue(root)
+			if hasClass {
+				data.DeviceClass = types.StringValue(deviceClass)
+			}
+		case strings.HasPrefix(step.Op, "choose") && step.Type != "":
+			if data.FailureDomain.IsNull() {
+				data.FailureDomain = types.StringValue(step.Type)
+			}
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/crush_rule_resource_test.go
+++ b/crush_rule_resource_test.go
@@ -99,7 +99,6 @@ func TestAccCephCrushRuleResource_replicated(t *testing.T) {
 				ImportStateVerify:                    true,
 				ImportStateId:                        ruleName,
 				ImportStateVerifyIdentifierAttribute: "name",
-				ImportStateVerifyIgnore:              []string{"pool_type", "failure_domain", "device_class", "profile", "root"},
 			},
 		},
 	})
@@ -221,7 +220,8 @@ func TestAccCephCrushRuleResource_erasure(t *testing.T) {
 				ImportStateVerify:                    true,
 				ImportStateId:                        ruleName,
 				ImportStateVerifyIdentifierAttribute: "name",
-				ImportStateVerifyIgnore:              []string{"pool_type", "failure_domain", "device_class", "profile", "root"},
+				// The erasure profile is not recoverable from the rule dump.
+				ImportStateVerifyIgnore: []string{"profile"},
 			},
 		},
 	})
@@ -626,6 +626,63 @@ func TestAccCephCrushRuleResource_FailureDomainMismatchWithProfile(t *testing.T)
 					}
 				`, profileName, ruleName),
 				ExpectError: regexp.MustCompile(`Failure Domain Mismatch`),
+			},
+		},
+	})
+}
+
+func TestAccCephCrushRuleResource_importOutOfBand(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	ruleName := fmt.Sprintf("test-import-oob-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	config := testAccProviderConfigBlock + fmt.Sprintf(`
+		resource "ceph_crush_rule" "test" {
+		  name           = %q
+		  pool_type      = "replicated"
+		  failure_domain = "host"
+		}
+	`, ruleName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephCrushRuleDestroy(t),
+		PreCheck: func() {
+			testAccPreCheckCephHealth(t)
+
+			if err := cephTestClusterCLI.CrushRuleCreateReplicated(t.Context(), ruleName, "default", "host"); err != nil {
+				t.Fatalf("Failed to create crush rule out of band: %v", err)
+			}
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables:    testAccProviderConfig(),
+				Config:             config,
+				ResourceName:       "ceph_crush_rule.test",
+				ImportState:        true,
+				ImportStateId:      ruleName,
+				ImportStatePersist: true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 state, got %d", len(states))
+					}
+					attrs := states[0].Attributes
+					if attrs["failure_domain"] != "host" {
+						return fmt.Errorf("expected failure_domain host, got %q", attrs["failure_domain"])
+					}
+					if attrs["root"] != "default" {
+						return fmt.Errorf("expected root default, got %q", attrs["root"])
+					}
+					return nil
+				},
+			},
+			// The plan after import must be empty; before placement
+			// attributes were recovered it forced a replacement.
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config:          config,
+				PlanOnly:        true,
 			},
 		},
 	})


### PR DESCRIPTION
ImportState left failure_domain, root, and device_class null - with failure_domain Required and all three RequiresReplace, the first plan after an import always destroyed and recreated the rule (and failed outright if a pool used it). Derive them from the rule's steps: root and device class from the take step's item_name, failure domain from the first choose step's bucket type. The erasure profile is still not recoverable and must be set in config to match.