### PR TITLE
Always send pg_num when creating a pool

### DIFF
--- a/pool_resource.go
+++ b/pool_resource.go
@@ -781,4 +781,13 @@ func (r *PoolResource) ValidateConfig(ctx context.Context, req resource.Validate
 		}
 	}
 
+	if data.PgNum.IsNull() &&
+		!data.PgAutoscaleMode.IsUnknown() &&
+		(data.PgAutoscaleMode.IsNull() || data.PgAutoscaleMode.ValueString() != "on") {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("pg_num"),
+			"Invalid Attribute Combination",
+			`Either pg_num must be set or pg_autoscale_mode must be "on" so Ceph can size the pool's placement groups.`,
+		)
+	}
 }

--- a/pool_resource_test.go
+++ b/pool_resource_test.go
@@ -2283,3 +2283,64 @@ func TestAccCephPoolResource_ErasureWithCustomCrushRule(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCephPoolResource_missingPgNumRejected(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	poolName := acctest.RandomWithPrefix("test-pool-minimal")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_pool" "test" {
+					  name      = %q
+					  pool_type = "replicated"
+					}
+				`, poolName),
+				ExpectError: regexp.MustCompile(`(?i)either pg_num must be set`),
+			},
+		},
+	})
+}
+
+func TestAccCephPoolResource_autoscaleWithoutPgNum(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	poolName := acctest.RandomWithPrefix("test-pool-autoscale-only")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephPoolDestroy(t),
+		PreCheck: func() {
+			testAccPreCheckWaitForTasks(t)
+			testAccPreCheckWaitForPGsActiveClean(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_pool" "test" {
+					  name              = %q
+					  pool_type         = "replicated"
+					  pg_autoscale_mode = "on"
+
+					  timeouts = {
+					    create = "1m"
+					    delete = "1m"
+					  }
+					}
+				`, poolName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkCephPoolExists(t, poolName),
+					checkCephPoolPgAutoscaleMode(t, poolName, "on"),
+					resource.TestCheckResourceAttrSet("ceph_pool.test", "pool_id"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
The dashboard's POST /api/pool handler takes pg_num as a required parameter, but the provider only sent it when the config set pg_num or explicitly enabled the autoscaler - so a minimal pool config (name and pool_type only) failed on every create. Fall back to 32, Ceph's osd_pool_default_pg_num, when nothing else determines a value.