### PR TITLE
Require pg_num or the autoscaler when creating a pool

### DIFF
--- a/pool_resource.go
+++ b/pool_resource.go
@@ -781,4 +781,13 @@ func (r *PoolResource) ValidateConfig(ctx context.Context, req resource.Validate
 		}
 	}
 
+	if data.PgNum.IsNull() &&
+		!data.PgAutoscaleMode.IsUnknown() &&
+		(data.PgAutoscaleMode.IsNull() || data.PgAutoscaleMode.ValueString() != "on") {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("pg_num"),
+			"Invalid Attribute Combination",
+			`Either pg_num must be set or pg_autoscale_mode must be "on" so Ceph can size the pool's placement groups.`,
+		)
+	}
 }

--- a/pool_resource_test.go
+++ b/pool_resource_test.go
@@ -2283,3 +2283,64 @@ func TestAccCephPoolResource_ErasureWithCustomCrushRule(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCephPoolResource_missingPgNumRejected(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	poolName := acctest.RandomWithPrefix("test-pool-minimal")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_pool" "test" {
+					  name      = %q
+					  pool_type = "replicated"
+					}
+				`, poolName),
+				ExpectError: regexp.MustCompile(`(?i)either pg_num must be set`),
+			},
+		},
+	})
+}
+
+func TestAccCephPoolResource_autoscaleWithoutPgNum(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	poolName := acctest.RandomWithPrefix("test-pool-autoscale-only")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephPoolDestroy(t),
+		PreCheck: func() {
+			testAccPreCheckWaitForTasks(t)
+			testAccPreCheckWaitForPGsActiveClean(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_pool" "test" {
+					  name              = %q
+					  pool_type         = "replicated"
+					  pg_autoscale_mode = "on"
+
+					  timeouts = {
+					    create = "1m"
+					    delete = "1m"
+					  }
+					}
+				`, poolName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkCephPoolExists(t, poolName),
+					checkCephPoolPgAutoscaleMode(t, poolName, "on"),
+					resource.TestCheckResourceAttrSet("ceph_pool.test", "pool_id"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
The dashboard's pool create endpoint requires pg_num, so a config with neither pg_num nor pg_autoscale_mode = "on" always failed - with an opaque 500 ("AssertionError: pg_num is required") at apply time. Enforce the choice at plan time with a clear error instead of inventing a default that would override a tuned osd_pool_default_pg_num.