### PR TITLE
Validate token via auth check response body

### DIFF
--- a/internal/restapi/auth.go
+++ b/internal/restapi/auth.go
@@ -145,7 +145,25 @@ func (c *Client) AuthCheck(ctx context.Context) (bool, error) {
 
 	switch httpResp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
-		return true, nil
+		body, err := io.ReadAll(httpResp.Body)
+		if err != nil {
+			return false, fmt.Errorf("unable to read check response: %w", err)
+		}
+
+		tflog.Trace(ctx, "Ceph API response body", map[string]any{
+			"response_body": string(body),
+			"status_code":   httpResp.StatusCode,
+		})
+
+		// The auth/check endpoint is unauthenticated and returns 200 even
+		// for a bad token; only an authenticated response echoes a username.
+		var checkResp struct {
+			Username string `json:"username"`
+		}
+		if err := json.Unmarshal(body, &checkResp); err != nil {
+			return false, fmt.Errorf("unable to decode check response: %w", err)
+		}
+		return checkResp.Username != "", nil
 	case http.StatusUnauthorized:
 		return false, fmt.Errorf("token is invalid or expired")
 	default:

--- a/provider_test.go
+++ b/provider_test.go
@@ -1047,6 +1047,68 @@ func TestAccProvider_tokenAuthentication(t *testing.T) {
 	})
 }
 
+func TestAccProvider_invalidTokenAuthentication(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: config.Variables{
+					"endpoint": config.StringVariable(testDashboardURL),
+				},
+				Config: `
+					variable "endpoint" {
+					  type = string
+					}
+
+					provider "ceph" {
+					  endpoint = var.endpoint
+					  token    = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIn0.aW52YWxpZC1zaWduYXR1cmU"
+					}
+
+					data "ceph_auth" "test" {
+					  entity = "client.admin"
+					}
+				`,
+				ExpectError: regexp.MustCompile(`provided token is invalid or expired`),
+			},
+		},
+	})
+}
+
+func TestAccProvider_invalidJWTSecretAuthentication(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: config.Variables{
+					"endpoint": config.StringVariable(testDashboardURL),
+				},
+				Config: `
+					variable "endpoint" {
+					  type = string
+					}
+
+					provider "ceph" {
+					  endpoint   = var.endpoint
+					  jwt_secret = "d3Jvbmctc2VjcmV0LXdyb25nLXNlY3JldA=="
+					}
+
+					data "ceph_auth" "test" {
+					  entity = "client.admin"
+					}
+				`,
+				ExpectError: regexp.MustCompile(`signed JWT token is invalid`),
+			},
+		},
+	})
+}
+
 func TestAccProvider_jwtSecretAuthentication(t *testing.T) {
 	detachLogs := cephDaemonLogs.AttachTestFunction(t)
 	defer detachLogs()


### PR DESCRIPTION
The dashboard auth/check endpoint is unauthenticated and returns HTTP 200 even for an invalid or expired token, so status-based validation always passed and a bad token only surfaced later as a confusing 401 mid-apply. Require an authenticated response body (non-empty username) to report the token as valid.

Adds `TestAccProvider_invalidTokenAuthentication` (well-formed JWT with a bad signature) and `TestAccProvider_invalidJWTSecretAuthentication` (wrong `jwt_secret`), both verified red before the fix and green after.