### PR TITLE
Keep mgr module config raw values on read back

### DIFF
--- a/config_resource.go
+++ b/config_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/josh/terraform-provider-ceph/internal/cephvalues"
 	"github.com/josh/terraform-provider-ceph/internal/restapi"
 )
 
@@ -162,7 +163,7 @@ func (r *ConfigResource) Read(ctx context.Context, req resource.ReadRequest, res
 				// Ceph stores a canonicalized form of the value, so keep the
 				// state's spelling when it means the same thing to avoid a
 				// perpetual diff (e.g. "0.5" vs "0.500000").
-				if configValuesEqual(apiConfig.Type, configs[name], v.Value) {
+				if cephvalues.ClusterEqual(apiConfig.Type, configs[name], v.Value) {
 					updatedConfigs[name] = configs[name]
 				} else {
 					updatedConfigs[name] = v.Value

--- a/internal/cephvalues/cluster.go
+++ b/internal/cephvalues/cluster.go
@@ -1,11 +1,15 @@
-// Package cephvalues compares and formats Ceph option value spellings.
+// Package cephvalues compares and formats Ceph option values.
 //
-// Cluster config options (mon) are parsed at set time by strict C++
-// parsers in src/common and stored canonicalized, while mgr module
-// options are stored as raw strings and coerced typed at read time by
-// src/mgr/PyUtil.cc. The two backends accept different spellings for the
-// same option types (suffixes, bool synonyms, durations), so their
-// helpers are deliberately separate.
+// The mon validates and normalizes every option value at set time:
+// Option::parse_value (src/common/options.cc) parses the raw value with
+// the strict parsers in src/common and stores the normalized value it
+// produces, for cluster config and mgr module options alike. Cluster
+// config reads return the normalized value, so ClusterEqual mirrors those
+// parsers directly. Mgr module reads instead coerce a cached string typed
+// via src/mgr/PyUtil.cc — the raw value until the mgr refreshes its
+// config, the normalized value after — so MgrModuleString only preserves
+// raw values both readings agree on. The accepted forms differ per
+// backend, which is why the helpers are deliberately separate.
 package cephvalues
 
 import (
@@ -15,10 +19,10 @@ import (
 	"strings"
 )
 
-// ClusterEqual reports whether two spellings mean the same cluster config
+// ClusterEqual reports whether two raw values mean the same cluster config
 // value for a given option type, mirroring the upstream parsers
 // (strict_strtob, strict_si_cast, strict_iec_cast, parse_timespan, stoull)
-// and the canonical forms produced by Option::to_str.
+// and the normalized values produced by Option::to_str.
 func ClusterEqual(optType, a, b string) bool {
 	if a == b {
 		return true
@@ -229,9 +233,9 @@ func parseLeadingUint(s string) (uint64, bool) {
 	return v, err == nil
 }
 
-// addr options are canonicalized through entity_addr_t, which adds a msgr2
+// addr options are normalized through entity_addr_t, which adds a msgr2
 // type prefix, default port, and nonce ("1.2.3.4" is stored as
-// "v2:1.2.3.4:0/0"). Only exact decorated forms of the other spelling are
+// "v2:1.2.3.4:0/0"). Only exact decorated forms of the other value are
 // recognized; anything else stays unequal.
 func addrEqual(a, b string) bool {
 	a, b = strings.TrimSpace(a), strings.TrimSpace(b)

--- a/internal/cephvalues/cluster.go
+++ b/internal/cephvalues/cluster.go
@@ -1,4 +1,12 @@
-package main
+// Package cephvalues compares and formats Ceph option value spellings.
+//
+// Cluster config options (mon) are parsed at set time by strict C++
+// parsers in src/common and stored canonicalized, while mgr module
+// options are stored as raw strings and coerced typed at read time by
+// src/mgr/PyUtil.cc. The two backends accept different spellings for the
+// same option types (suffixes, bool synonyms, durations), so their
+// helpers are deliberately separate.
+package cephvalues
 
 import (
 	"math"
@@ -7,30 +15,27 @@ import (
 	"strings"
 )
 
-// Ceph normalizes option values before storing them (bool → "true"/"false",
-// float → fixed-point, size/secs suffixes → plain numbers), so the value in
-// `config dump` rarely matches the user's literal input byte-for-byte.
-// configValuesEqual reports whether two spellings mean the same value for a
-// given option type, mirroring the upstream parsers in src/common
+// ClusterEqual reports whether two spellings mean the same cluster config
+// value for a given option type, mirroring the upstream parsers
 // (strict_strtob, strict_si_cast, strict_iec_cast, parse_timespan, stoull)
 // and the canonical forms produced by Option::to_str.
-func configValuesEqual(optType, a, b string) bool {
+func ClusterEqual(optType, a, b string) bool {
 	if a == b {
 		return true
 	}
 
 	switch optType {
 	case "bool":
-		av, aok := parseCephBool(a)
-		bv, bok := parseCephBool(b)
+		av, aok := parseBool(a)
+		bv, bok := parseBool(b)
 		return aok && bok && av == bv
 	case "int", "uint":
-		av, aok := parseCephSIInt(a)
-		bv, bok := parseCephSIInt(b)
+		av, aok := parseSIInt(a)
+		bv, bok := parseSIInt(b)
 		return aok && bok && av == bv
 	case "size":
-		av, aok := parseCephIECInt(a)
-		bv, bok := parseCephIECInt(b)
+		av, aok := parseIECInt(a)
+		bv, bok := parseIECInt(b)
 		return aok && bok && av == bv
 	case "float":
 		af, aerr := strconv.ParseFloat(strings.TrimSpace(a), 64)
@@ -39,8 +44,8 @@ func configValuesEqual(optType, a, b string) bool {
 		return aerr == nil && berr == nil &&
 			strconv.FormatFloat(af, 'f', 6, 64) == strconv.FormatFloat(bf, 'f', 6, 64)
 	case "secs":
-		av, aok := parseCephTimespan(a)
-		bv, bok := parseCephTimespan(b)
+		av, aok := parseTimespan(a)
+		bv, bok := parseTimespan(b)
 		return aok && bok && av == bv
 	case "millisecs":
 		// Parsed with stoull, which reads the leading digits and ignores
@@ -51,13 +56,13 @@ func configValuesEqual(optType, a, b string) bool {
 	case "uuid":
 		return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
 	case "addr":
-		return cephAddrEqual(a, b) || cephAddrEqual(b, a)
+		return addrEqual(a, b) || addrEqual(b, a)
 	default:
 		return false
 	}
 }
 
-func parseCephBool(s string) (bool, bool) {
+func parseBool(s string) (bool, bool) {
 	s = strings.TrimSpace(s)
 	if strings.EqualFold(s, "true") {
 		return true, true
@@ -71,11 +76,11 @@ func parseCephBool(s string) (bool, bool) {
 	return false, false
 }
 
-var configScaleExponents = map[byte]int{'K': 1, 'M': 2, 'G': 3, 'T': 4, 'P': 5, 'E': 6}
+var scaleExponents = map[byte]int{'K': 1, 'M': 2, 'G': 3, 'T': 4, 'P': 5, 'E': 6}
 
 // int/uint options take a single trailing decimal suffix: K/M/G/T/P/E
 // multiply by powers of 1000, B multiplies by one.
-func parseCephSIInt(s string) (int64, bool) {
+func parseSIInt(s string) (int64, bool) {
 	s = strings.TrimSpace(s)
 	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
 		return v, true
@@ -90,7 +95,7 @@ func parseCephSIInt(s string) (int64, bool) {
 		v, err := strconv.ParseInt(num, 10, 64)
 		return v, err == nil
 	}
-	exp, ok := configScaleExponents[suffix]
+	exp, ok := scaleExponents[suffix]
 	if !ok {
 		return 0, false
 	}
@@ -104,7 +109,7 @@ func parseCephSIInt(s string) (int64, bool) {
 // size options take binary suffixes: K/M/G/T/P/E and Ki/Mi/... all multiply
 // by powers of 1024, with an optional trailing B ("1K" = "1KiB" = 1024,
 // "100B" = 100).
-func parseCephIECInt(s string) (int64, bool) {
+func parseIECInt(s string) (int64, bool) {
 	s = strings.TrimSpace(s)
 	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
 		return v, true
@@ -126,7 +131,7 @@ func parseCephIECInt(s string) (int64, bool) {
 	if len(unit) == 0 || len(unit) > 2 || (len(unit) == 2 && unit[1] != 'i') {
 		return 0, false
 	}
-	exp, ok := configScaleExponents[unit[0]]
+	exp, ok := scaleExponents[unit[0]]
 	if !ok {
 		return 0, false
 	}
@@ -147,7 +152,7 @@ func scaleInt(v int64, base int64, exp int) (int64, bool) {
 	return v, true
 }
 
-var configTimespanUnits = map[string]int64{
+var timespanUnits = map[string]int64{
 	"s": 1, "sec": 1, "second": 1, "seconds": 1,
 	"m": 60, "min": 60, "minute": 60, "minutes": 60,
 	"h": 3600, "hr": 3600, "hour": 3600, "hours": 3600,
@@ -159,7 +164,7 @@ var configTimespanUnits = map[string]int64{
 
 // secs options are parsed by summing value/unit pairs ("1h 30m" = 5400); a
 // bare trailing number counts as seconds.
-func parseCephTimespan(s string) (int64, bool) {
+func parseTimespan(s string) (int64, bool) {
 	var total int64
 	parsedAny := false
 
@@ -193,7 +198,7 @@ func parseCephTimespan(s string) (int64, bool) {
 			pos++
 		}
 		if start != pos {
-			mult, ok := configTimespanUnits[s[start:pos]]
+			mult, ok := timespanUnits[s[start:pos]]
 			if !ok {
 				return 0, false
 			}
@@ -228,7 +233,7 @@ func parseLeadingUint(s string) (uint64, bool) {
 // type prefix, default port, and nonce ("1.2.3.4" is stored as
 // "v2:1.2.3.4:0/0"). Only exact decorated forms of the other spelling are
 // recognized; anything else stays unequal.
-func cephAddrEqual(a, b string) bool {
+func addrEqual(a, b string) bool {
 	a, b = strings.TrimSpace(a), strings.TrimSpace(b)
 	if a == b {
 		return true

--- a/internal/cephvalues/cluster_test.go
+++ b/internal/cephvalues/cluster_test.go
@@ -1,8 +1,8 @@
-package main
+package cephvalues
 
 import "testing"
 
-func TestConfigValuesEqual(t *testing.T) {
+func TestClusterEqual(t *testing.T) {
 	tests := []struct {
 		optType string
 		a, b    string
@@ -82,8 +82,8 @@ func TestConfigValuesEqual(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := configValuesEqual(tt.optType, tt.a, tt.b); got != tt.want {
-			t.Errorf("configValuesEqual(%q, %q, %q) = %v, want %v", tt.optType, tt.a, tt.b, got, tt.want)
+		if got := ClusterEqual(tt.optType, tt.a, tt.b); got != tt.want {
+			t.Errorf("ClusterEqual(%q, %q, %q) = %v, want %v", tt.optType, tt.a, tt.b, got, tt.want)
 		}
 	}
 }

--- a/internal/cephvalues/mgrmodule.go
+++ b/internal/cephvalues/mgrmodule.go
@@ -1,0 +1,70 @@
+package cephvalues
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// FormatMgrModuleValue renders a typed mgr module option value (as decoded
+// from the dashboard's JSON response) back into its string spelling.
+func FormatMgrModuleValue(val any) (string, error) {
+	switch v := val.(type) {
+	case nil:
+		return "", nil
+	case float64:
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v)), nil
+		}
+		return strconv.FormatFloat(v, 'g', -1, 64), nil
+	case float32:
+		if v == float32(int32(v)) {
+			return fmt.Sprintf("%d", int32(v)), nil
+		}
+		return strconv.FormatFloat(float64(v), 'g', -1, 32), nil
+	case int, int8, int16, int32, int64:
+		return fmt.Sprintf("%d", v), nil
+	case uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", v), nil
+	case bool:
+		return fmt.Sprintf("%t", v), nil
+	case string:
+		return v, nil
+	default:
+		return "", fmt.Errorf("unsupported config value type: %T", v)
+	}
+}
+
+// The mgr stores module options as raw strings and coerces them typed at
+// read time (src/mgr/PyUtil.cc), so the read-back rarely matches the user's
+// literal spelling (e.g. "1" reads back as bool true). MgrModuleString
+// keeps the prior spelling when it means the same value so applies stay
+// consistent and plans converge. The bool spellings mirror the mgr's
+// exact-case true list; false spellings are safe because anything outside
+// that list coerces to false.
+func MgrModuleString(prior string, val any) (string, error) {
+	formatted, err := FormatMgrModuleValue(val)
+	if err != nil || prior == formatted {
+		return formatted, err
+	}
+
+	equal := false
+	switch v := val.(type) {
+	case bool:
+		switch strings.TrimSpace(prior) {
+		case "1", "true", "True", "on", "yes":
+			equal = v
+		case "0", "false", "False", "off", "no":
+			equal = !v
+		}
+	case float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		p, perr := strconv.ParseFloat(strings.TrimSpace(prior), 64)
+		f, ferr := strconv.ParseFloat(formatted, 64)
+		equal = perr == nil && ferr == nil && p == f
+	}
+
+	if equal {
+		return prior, nil
+	}
+	return formatted, nil
+}

--- a/internal/cephvalues/mgrmodule.go
+++ b/internal/cephvalues/mgrmodule.go
@@ -1,17 +1,20 @@
 package cephvalues
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 )
 
 // FormatMgrModuleValue renders a typed mgr module option value (as decoded
-// from the dashboard's JSON response) back into its string spelling.
+// from the dashboard's JSON response) back into a string.
 func FormatMgrModuleValue(val any) (string, error) {
 	switch v := val.(type) {
 	case nil:
 		return "", nil
+	case json.Number:
+		return string(v), nil
 	case float64:
 		if v == float64(int64(v)) {
 			return fmt.Sprintf("%d", int64(v)), nil
@@ -35,13 +38,17 @@ func FormatMgrModuleValue(val any) (string, error) {
 	}
 }
 
-// The mgr stores module options as raw strings and coerces them typed at
-// read time (src/mgr/PyUtil.cc), so the read-back rarely matches the user's
-// literal spelling (e.g. "1" reads back as bool true). MgrModuleString
-// keeps the prior spelling when it means the same value so applies stay
-// consistent and plans converge. The bool spellings mirror the mgr's
-// exact-case true list; false spellings are safe because anything outside
-// that list coerces to false.
+// MgrModuleString keeps the prior raw value of an mgr module option when
+// it means the same value as the typed read-back, so applies stay
+// consistent and plans converge. The mon validates and normalizes the
+// value at set time, but the mgr serves the raw value from its local
+// cache until the next config refresh and coerces whichever string it
+// holds typed at read time (src/mgr/PyUtil.cc). A raw value is therefore
+// preserved only when the raw and normalized readings agree: bools via
+// the read-time exact-case true list intersected with the mon's parse,
+// integers via exact base-10 comparison without leading zeros (PyLong
+// base 0 rejects them), floats rounded to the mon's six-decimal
+// normalized form.
 func MgrModuleString(prior string, val any) (string, error) {
 	formatted, err := FormatMgrModuleValue(val)
 	if err != nil || prior == formatted {
@@ -51,20 +58,44 @@ func MgrModuleString(prior string, val any) (string, error) {
 	equal := false
 	switch v := val.(type) {
 	case bool:
-		switch strings.TrimSpace(prior) {
-		case "1", "true", "True", "on", "yes":
+		switch prior {
+		case "1", "true", "True":
 			equal = v
-		case "0", "false", "False", "off", "no":
-			equal = !v
+		default:
+			if pv, ok := parseBool(prior); ok && !pv {
+				equal = !v
+			}
 		}
-	case float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		p, perr := strconv.ParseFloat(strings.TrimSpace(prior), 64)
-		f, ferr := strconv.ParseFloat(formatted, 64)
-		equal = perr == nil && ferr == nil && p == f
+	case json.Number:
+		if strings.ContainsAny(string(v), ".eE") {
+			equal = floatValuesEqual(prior, string(v))
+		} else {
+			equal = intValuesEqual(prior, string(v))
+		}
+	case float32, float64:
+		equal = floatValuesEqual(prior, formatted)
 	}
 
 	if equal {
 		return prior, nil
 	}
 	return formatted, nil
+}
+
+func intValuesEqual(a, b string) bool {
+	digits := strings.TrimLeft(strings.TrimSpace(a), "+-")
+	if len(digits) > 1 && digits[0] == '0' {
+		return false
+	}
+
+	av, aerr := strconv.ParseInt(strings.TrimSpace(a), 10, 64)
+	bv, berr := strconv.ParseInt(b, 10, 64)
+	return aerr == nil && berr == nil && av == bv
+}
+
+func floatValuesEqual(a, b string) bool {
+	av, aerr := strconv.ParseFloat(strings.TrimSpace(a), 64)
+	bv, berr := strconv.ParseFloat(b, 64)
+	return aerr == nil && berr == nil &&
+		strconv.FormatFloat(av, 'f', 6, 64) == strconv.FormatFloat(bv, 'f', 6, 64)
 }

--- a/internal/cephvalues/mgrmodule_test.go
+++ b/internal/cephvalues/mgrmodule_test.go
@@ -1,6 +1,9 @@
 package cephvalues
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestMgrModuleString(t *testing.T) {
 	tests := []struct {
@@ -11,21 +14,44 @@ func TestMgrModuleString(t *testing.T) {
 		{"1", true, "1"},
 		{"true", true, "true"},
 		{"True", true, "True"},
-		{"on", true, "on"},
-		{"yes", true, "yes"},
-		{"0", false, "0"},
-		{"off", false, "off"},
-		{"no", false, "no"},
+
+		// The mgr's read-time coercion treats these as false until the
+		// mon's normalized value replaces the cached raw value, so they
+		// must not be preserved as true values.
 		{"TRUE", true, "true"},
+		{"on", true, "true"},
+		{"yes", true, "true"},
+		{" 1", true, "true"},
+		{"2", true, "true"},
+
+		{"0", false, "0"},
+		{"false", false, "false"},
+		{"False", false, "False"},
+		{"FALSE", false, "FALSE"},
+		{"off", false, "false"},
+		{"no", false, "false"},
 		{"TRUE", false, "false"},
 		{"1", false, "false"},
-		{"yes", false, "false"},
 
-		{"8080", float64(8080), "8080"},
+		{"8080", json.Number("8080"), "8080"},
+		{"+8080", json.Number("8080"), "+8080"},
+		{"9007199254740993", json.Number("9007199254740993"), "9007199254740993"},
+		{"9007199254740993", json.Number("9007199254740992"), "9007199254740992"},
+		// PyLong base 0 rejects leading zeros, so the cached raw value
+		// fails the mgr's read-time coercion.
+		{"08080", json.Number("8080"), "8080"},
+		{"1K", json.Number("1000"), "1000"},
+		{"3", json.Number("2"), "2"},
+
+		{"2.0", json.Number("2.0"), "2.0"},
+		{"2", json.Number("2.0"), "2"},
+		{"0.1234567", json.Number("0.1234567"), "0.1234567"},
+		{"0.1234567", json.Number("0.123457"), "0.1234567"},
+		{"1e3", json.Number("1000.0"), "1e3"},
+		{"2.5", json.Number("2.51"), "2.51"},
+
 		{"2.0", float64(2), "2.0"},
-		{"08080", float64(8080), "08080"},
-		{"2.5", float64(2.5), "2.5"},
-		{"3", float64(2), "2"},
+		{"0.1234567", float64(0.123457), "0.1234567"},
 		{"abc", float64(2), "2"},
 
 		{"hello", "hello", "hello"},
@@ -57,6 +83,9 @@ func TestFormatMgrModuleValue(t *testing.T) {
 		{nil, ""},
 		{true, "true"},
 		{false, "false"},
+		{json.Number("8080"), "8080"},
+		{json.Number("9007199254740993"), "9007199254740993"},
+		{json.Number("2.5"), "2.5"},
 		{float64(8080), "8080"},
 		{float64(2.5), "2.5"},
 		{int64(-3), "-3"},

--- a/internal/cephvalues/mgrmodule_test.go
+++ b/internal/cephvalues/mgrmodule_test.go
@@ -1,0 +1,77 @@
+package cephvalues
+
+import "testing"
+
+func TestMgrModuleString(t *testing.T) {
+	tests := []struct {
+		prior string
+		val   any
+		want  string
+	}{
+		{"1", true, "1"},
+		{"true", true, "true"},
+		{"True", true, "True"},
+		{"on", true, "on"},
+		{"yes", true, "yes"},
+		{"0", false, "0"},
+		{"off", false, "off"},
+		{"no", false, "no"},
+		{"TRUE", true, "true"},
+		{"TRUE", false, "false"},
+		{"1", false, "false"},
+		{"yes", false, "false"},
+
+		{"8080", float64(8080), "8080"},
+		{"2.0", float64(2), "2.0"},
+		{"08080", float64(8080), "08080"},
+		{"2.5", float64(2.5), "2.5"},
+		{"3", float64(2), "2"},
+		{"abc", float64(2), "2"},
+
+		{"hello", "hello", "hello"},
+		{"other", "hello", "hello"},
+		{"", nil, ""},
+	}
+
+	for _, tt := range tests {
+		got, err := MgrModuleString(tt.prior, tt.val)
+		if err != nil {
+			t.Errorf("MgrModuleString(%q, %v) returned error: %v", tt.prior, tt.val, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("MgrModuleString(%q, %v) = %q, want %q", tt.prior, tt.val, got, tt.want)
+		}
+	}
+
+	if _, err := MgrModuleString("x", struct{}{}); err == nil {
+		t.Error("MgrModuleString with unsupported type should return an error")
+	}
+}
+
+func TestFormatMgrModuleValue(t *testing.T) {
+	tests := []struct {
+		val  any
+		want string
+	}{
+		{nil, ""},
+		{true, "true"},
+		{false, "false"},
+		{float64(8080), "8080"},
+		{float64(2.5), "2.5"},
+		{int64(-3), "-3"},
+		{uint32(7), "7"},
+		{"text", "text"},
+	}
+
+	for _, tt := range tests {
+		got, err := FormatMgrModuleValue(tt.val)
+		if err != nil {
+			t.Errorf("FormatMgrModuleValue(%v) returned error: %v", tt.val, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("FormatMgrModuleValue(%v) = %q, want %q", tt.val, got, tt.want)
+		}
+	}
+}

--- a/internal/restapi/mgr_module.go
+++ b/internal/restapi/mgr_module.go
@@ -58,8 +58,13 @@ func (c *Client) MgrGetModuleConfig(ctx context.Context, moduleName string) (Mgr
 		"status_code":   httpResp.StatusCode,
 	})
 
+	// Decode numbers as json.Number so integer option values survive
+	// beyond float64 precision.
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
 	var config MgrModuleConfig
-	err = json.Unmarshal(body, &config)
+	err = decoder.Decode(&config)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode JSON response: %w", err)
 	}

--- a/mgr_module_config_data_source.go
+++ b/mgr_module_config_data_source.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/josh/terraform-provider-ceph/internal/cephvalues"
 	"github.com/josh/terraform-provider-ceph/internal/restapi"
 )
 
@@ -94,7 +94,7 @@ func (d *MgrModuleConfigDataSource) Read(ctx context.Context, req datasource.Rea
 
 	configMap := make(map[string]string)
 	for key, value := range config {
-		formattedVal, err := formatMgrModuleConfigValue(value)
+		formattedVal, err := cephvalues.FormatMgrModuleValue(value)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Configuration Value Formatting Error",
@@ -115,31 +115,4 @@ func (d *MgrModuleConfigDataSource) Read(ctx context.Context, req datasource.Rea
 	data.ID = types.StringValue(moduleName)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func formatMgrModuleConfigValue(val any) (string, error) {
-	switch v := val.(type) {
-	case nil:
-		return "", nil
-	case float64:
-		if v == float64(int64(v)) {
-			return fmt.Sprintf("%d", int64(v)), nil
-		}
-		return strconv.FormatFloat(v, 'g', -1, 64), nil
-	case float32:
-		if v == float32(int32(v)) {
-			return fmt.Sprintf("%d", int32(v)), nil
-		}
-		return strconv.FormatFloat(float64(v), 'g', -1, 32), nil
-	case int, int8, int16, int32, int64:
-		return fmt.Sprintf("%d", v), nil
-	case uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%d", v), nil
-	case bool:
-		return fmt.Sprintf("%t", v), nil
-	case string:
-		return v, nil
-	default:
-		return "", fmt.Errorf("unsupported config value type: %T", v)
-	}
 }

--- a/mgr_module_config_resource.go
+++ b/mgr_module_config_resource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -31,6 +33,39 @@ type MgrModuleConfigResourceModel struct {
 	ModuleName types.String `tfsdk:"module_name"`
 	Configs    types.Map    `tfsdk:"configs"`
 	ID         types.String `tfsdk:"id"`
+}
+
+// The mgr stores module options as raw strings and coerces them typed at
+// read time (src/mgr/PyUtil.cc), so the read-back rarely matches the user's
+// literal spelling (e.g. "1" reads back as bool true). Keep the prior
+// spelling when it means the same value so applies stay consistent and plans
+// converge. The bool spellings mirror the mgr's exact-case true list; false
+// spellings are safe because anything outside that list coerces to false.
+func mgrModuleConfigValueString(prior string, val any) (string, error) {
+	formatted, err := formatMgrModuleConfigValue(val)
+	if err != nil || prior == formatted {
+		return formatted, err
+	}
+
+	equal := false
+	switch v := val.(type) {
+	case bool:
+		switch strings.TrimSpace(prior) {
+		case "1", "true", "True", "on", "yes":
+			equal = v
+		case "0", "false", "False", "off", "no":
+			equal = !v
+		}
+	case float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		p, perr := strconv.ParseFloat(strings.TrimSpace(prior), 64)
+		f, ferr := strconv.ParseFloat(formatted, 64)
+		equal = perr == nil && ferr == nil && p == f
+	}
+
+	if equal {
+		return prior, nil
+	}
+	return formatted, nil
 }
 
 func (r *MgrModuleConfigResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -140,7 +175,7 @@ func (r *MgrModuleConfigResource) Create(ctx context.Context, req resource.Creat
 			)
 			return
 		}
-		formattedVal, err := formatMgrModuleConfigValue(val)
+		formattedVal, err := mgrModuleConfigValueString(configsMap[key], val)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Configuration Value Formatting Error",
@@ -195,7 +230,7 @@ func (r *MgrModuleConfigResource) Read(ctx context.Context, req resource.ReadReq
 	stringConfigs := make(map[string]string)
 	for key := range currentConfigsMap {
 		if val, ok := readConfigs[key]; ok {
-			formattedVal, err := formatMgrModuleConfigValue(val)
+			formattedVal, err := mgrModuleConfigValueString(currentConfigsMap[key], val)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Configuration Value Formatting Error",
@@ -298,7 +333,7 @@ func (r *MgrModuleConfigResource) Update(ctx context.Context, req resource.Updat
 			)
 			return
 		}
-		formattedVal, err := formatMgrModuleConfigValue(val)
+		formattedVal, err := mgrModuleConfigValueString(newConfigsMap[key], val)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Configuration Value Formatting Error",

--- a/mgr_module_config_resource.go
+++ b/mgr_module_config_resource.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -13,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/josh/terraform-provider-ceph/internal/cephvalues"
 	"github.com/josh/terraform-provider-ceph/internal/restapi"
 )
 
@@ -33,39 +32,6 @@ type MgrModuleConfigResourceModel struct {
 	ModuleName types.String `tfsdk:"module_name"`
 	Configs    types.Map    `tfsdk:"configs"`
 	ID         types.String `tfsdk:"id"`
-}
-
-// The mgr stores module options as raw strings and coerces them typed at
-// read time (src/mgr/PyUtil.cc), so the read-back rarely matches the user's
-// literal spelling (e.g. "1" reads back as bool true). Keep the prior
-// spelling when it means the same value so applies stay consistent and plans
-// converge. The bool spellings mirror the mgr's exact-case true list; false
-// spellings are safe because anything outside that list coerces to false.
-func mgrModuleConfigValueString(prior string, val any) (string, error) {
-	formatted, err := formatMgrModuleConfigValue(val)
-	if err != nil || prior == formatted {
-		return formatted, err
-	}
-
-	equal := false
-	switch v := val.(type) {
-	case bool:
-		switch strings.TrimSpace(prior) {
-		case "1", "true", "True", "on", "yes":
-			equal = v
-		case "0", "false", "False", "off", "no":
-			equal = !v
-		}
-	case float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		p, perr := strconv.ParseFloat(strings.TrimSpace(prior), 64)
-		f, ferr := strconv.ParseFloat(formatted, 64)
-		equal = perr == nil && ferr == nil && p == f
-	}
-
-	if equal {
-		return prior, nil
-	}
-	return formatted, nil
 }
 
 func (r *MgrModuleConfigResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -175,7 +141,7 @@ func (r *MgrModuleConfigResource) Create(ctx context.Context, req resource.Creat
 			)
 			return
 		}
-		formattedVal, err := mgrModuleConfigValueString(configsMap[key], val)
+		formattedVal, err := cephvalues.MgrModuleString(configsMap[key], val)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Configuration Value Formatting Error",
@@ -230,7 +196,7 @@ func (r *MgrModuleConfigResource) Read(ctx context.Context, req resource.ReadReq
 	stringConfigs := make(map[string]string)
 	for key := range currentConfigsMap {
 		if val, ok := readConfigs[key]; ok {
-			formattedVal, err := mgrModuleConfigValueString(currentConfigsMap[key], val)
+			formattedVal, err := cephvalues.MgrModuleString(currentConfigsMap[key], val)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Configuration Value Formatting Error",
@@ -333,7 +299,7 @@ func (r *MgrModuleConfigResource) Update(ctx context.Context, req resource.Updat
 			)
 			return
 		}
-		formattedVal, err := mgrModuleConfigValueString(newConfigsMap[key], val)
+		formattedVal, err := cephvalues.MgrModuleString(newConfigsMap[key], val)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Configuration Value Formatting Error",
@@ -417,7 +383,7 @@ func (r *MgrModuleConfigResource) ImportState(ctx context.Context, req resource.
 			continue
 		}
 
-		valStr, err := formatMgrModuleConfigValue(val)
+		valStr, err := cephvalues.FormatMgrModuleValue(val)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Configuration Value Formatting Error",
@@ -426,7 +392,7 @@ func (r *MgrModuleConfigResource) ImportState(ctx context.Context, req resource.
 			return
 		}
 
-		defaultStr, err := formatMgrModuleConfigValue(option.DefaultValue)
+		defaultStr, err := cephvalues.FormatMgrModuleValue(option.DefaultValue)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Configuration Value Formatting Error",

--- a/mgr_module_config_resource_test.go
+++ b/mgr_module_config_resource_test.go
@@ -483,6 +483,52 @@ func TestAccCephMgrModuleConfigResource_booleanValues(t *testing.T) {
 	})
 }
 
+func TestAccCephMgrModuleConfigResource_normalizedValues(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	config := testAccProviderConfigBlock + `
+		resource "ceph_mgr_module_config" "test" {
+			module_name = "dashboard"
+			configs = {
+				ssl = "1"
+			}
+		}
+	`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephMgrModuleConfigDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config:          config,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ceph_mgr_module_config.test",
+						tfjsonpath.New("configs").AtMapKey("ssl"),
+						knownvalue.StringExact("1"),
+					),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					func(s *terraform.State) error {
+						return assertCephMgrModuleConfigValue(t.Context(), "dashboard", "ssl", "true")
+					},
+				),
+			},
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config:          config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccCephMgrModuleConfigResource_stringValues(t *testing.T) {
 	detachLogs := cephDaemonLogs.AttachTestFunction(t)
 	defer detachLogs()


### PR DESCRIPTION
The mgr stores module options typed, so setting a bool option to "1" read back as "true" and the apply failed with "provider produced inconsistent result". Keep the prior spelling when it means the same value as the typed read back.