### PR TITLE
Add ceph_rgw_role resource and data source

### DIFF
--- a/internal/cephcli/rgw_role.go
+++ b/internal/cephcli/rgw_role.go
@@ -1,0 +1,85 @@
+package cephcli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+var ErrRGWRoleNotFound = errors.New("rgw role not found")
+
+type RgwRoleInfo struct {
+	RoleID                   string `json:"RoleId"`
+	RoleName                 string `json:"RoleName"`
+	Path                     string `json:"Path"`
+	Arn                      string `json:"Arn"`
+	CreateDate               string `json:"CreateDate"`
+	MaxSessionDuration       int64  `json:"MaxSessionDuration"`
+	AssumeRolePolicyDocument string `json:"AssumeRolePolicyDocument"`
+}
+
+type rgwRoleGetOutput struct {
+	Role RgwRoleInfo `json:"role"`
+}
+
+func (c *CLI) RGWRoleCreate(ctx context.Context, name, path, assumePolicyDoc string) error {
+	args := []string{"--conf", c.confPath, "--format=json", "role", "create",
+		"--role-name=" + name, "--path=" + path, "--assume-role-policy-doc=" + assumePolicyDoc}
+
+	cmd := exec.CommandContext(ctx, "radosgw-admin", args...)
+	if _, err := cmd.Output(); err != nil {
+		return fmt.Errorf("failed to create rgw role %s: %w", name, err)
+	}
+
+	if _, err := c.RGWRoleGet(ctx, name); err != nil {
+		return fmt.Errorf("failed to verify rgw role creation: %w", err)
+	}
+
+	return nil
+}
+
+func (c *CLI) RGWRoleGet(ctx context.Context, name string) (*RgwRoleInfo, error) {
+	cmd := exec.CommandContext(ctx, "radosgw-admin", "--conf", c.confPath, "--format=json", "role", "get", "--role-name="+name)
+	output, err := cmd.Output()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("failed to get rgw role %s: %w", name, ErrRGWRoleNotFound)
+		}
+		return nil, fmt.Errorf("failed to get rgw role %s: %w", name, err)
+	}
+
+	var role RgwRoleInfo
+	if err := json.Unmarshal(output, &role); err == nil && role.RoleName != "" {
+		return &role, nil
+	}
+
+	var wrapped rgwRoleGetOutput
+	if err := json.Unmarshal(output, &wrapped); err != nil {
+		return nil, fmt.Errorf("failed to parse rgw role get output: %w", err)
+	}
+
+	return &wrapped.Role, nil
+}
+
+func (c *CLI) RGWRoleExists(ctx context.Context, name string) (bool, error) {
+	_, err := c.RGWRoleGet(ctx, name)
+	if err != nil {
+		if errors.Is(err, ErrRGWRoleNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (c *CLI) RGWRoleDelete(ctx context.Context, name string) error {
+	cmd := exec.CommandContext(ctx, "radosgw-admin", "--conf", c.confPath, "role", "delete", "--role-name="+name)
+	if _, err := cmd.Output(); err != nil {
+		return fmt.Errorf("failed to delete rgw role %s: %w", name, err)
+	}
+
+	return nil
+}

--- a/internal/restapi/rgw_role.go
+++ b/internal/restapi/rgw_role.go
@@ -1,0 +1,216 @@
+package restapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type RGWRole struct {
+	RoleID                   string `json:"RoleId"`
+	RoleName                 string `json:"RoleName"`
+	Path                     string `json:"Path"`
+	Arn                      string `json:"Arn"`
+	CreateDate               string `json:"CreateDate"`
+	MaxSessionDuration       int64  `json:"MaxSessionDuration"`
+	AssumeRolePolicyDocument string `json:"AssumeRolePolicyDocument"`
+	AccountID                string `json:"AccountId"`
+}
+
+// <https://docs.ceph.com/en/latest/mgr/ceph_api/#get--api-rgw-roles>
+
+func (c *Client) RGWListRoles(ctx context.Context) ([]RGWRole, error) {
+	url := c.endpoint.JoinPath("/api/rgw/roles").String()
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Accept", "application/vnd.ceph.api.v1.0+json")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.token)
+
+	logRequest := logAPIRequest(ctx, httpReq)
+	httpResp, err := c.client.Do(httpReq)
+	logRequest(httpResp, err)
+	if err != nil {
+		return nil, fmt.Errorf("unable to make request to Ceph API: %w", err)
+	}
+	defer httpResp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read response body: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	tflog.Trace(ctx, "Ceph API response body", map[string]any{
+		"response_body": string(body),
+		"status_code":   httpResp.StatusCode,
+	})
+
+	var roles []RGWRole
+	if err := json.Unmarshal(body, &roles); err != nil {
+		return nil, fmt.Errorf("unable to decode JSON response: %w", err)
+	}
+
+	return roles, nil
+}
+
+func (c *Client) RGWGetRole(ctx context.Context, name string) (*RGWRole, error) {
+	roles, err := c.RGWListRoles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, role := range roles {
+		if role.RoleName == name {
+			return &role, nil
+		}
+	}
+
+	return nil, ErrNotFound
+}
+
+// <https://docs.ceph.com/en/latest/mgr/ceph_api/#post--api-rgw-roles>
+
+type RGWRoleCreateRequest struct {
+	RoleName            string `json:"role_name"`
+	RolePath            string `json:"role_path"`
+	RoleAssumePolicyDoc string `json:"role_assume_policy_doc"`
+}
+
+func (c *Client) RGWCreateRole(ctx context.Context, req RGWRoleCreateRequest) error {
+	jsonPayload, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("unable to encode request payload: %w", err)
+	}
+
+	tflog.Trace(ctx, "Ceph API request body", map[string]any{
+		"request_body": string(jsonPayload),
+	})
+
+	url := c.endpoint.JoinPath("/api/rgw/roles").String()
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("unable to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Accept", "application/vnd.ceph.api.v1.0+json")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.token)
+
+	logRequest := logAPIRequest(ctx, httpReq)
+	httpResp, err := c.client.Do(httpReq)
+	logRequest(httpResp, err)
+	if err != nil {
+		return fmt.Errorf("unable to make request to Ceph API: %w", err)
+	}
+	defer httpResp.Body.Close() //nolint:errcheck
+
+	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(httpResp.Body)
+		return fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// <https://docs.ceph.com/en/latest/mgr/ceph_api/#put--api-rgw-roles>
+
+type rgwRoleUpdateRequest struct {
+	RoleName           string  `json:"role_name"`
+	MaxSessionDuration float64 `json:"max_session_duration"`
+}
+
+func (c *Client) RGWUpdateRole(ctx context.Context, name string, maxSessionDuration int64) error {
+	// The edit endpoint expects max_session_duration in hours and multiplies it
+	// back into seconds, unlike the read endpoint which reports seconds.
+	requestBody := rgwRoleUpdateRequest{
+		RoleName:           name,
+		MaxSessionDuration: float64(maxSessionDuration) / 3600.0,
+	}
+
+	jsonPayload, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("unable to encode request payload: %w", err)
+	}
+
+	tflog.Trace(ctx, "Ceph API request body", map[string]any{
+		"request_body": string(jsonPayload),
+	})
+
+	url := c.endpoint.JoinPath("/api/rgw/roles").String()
+	httpReq, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("unable to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Accept", "application/vnd.ceph.api.v1.0+json")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.token)
+
+	logRequest := logAPIRequest(ctx, httpReq)
+	httpResp, err := c.client.Do(httpReq)
+	logRequest(httpResp, err)
+	if err != nil {
+		return fmt.Errorf("unable to make request to Ceph API: %w", err)
+	}
+	defer httpResp.Body.Close() //nolint:errcheck
+
+	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(httpResp.Body)
+		return fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// <https://docs.ceph.com/en/latest/mgr/ceph_api/#delete--api-rgw-roles-role_name>
+
+func (c *Client) RGWDeleteRole(ctx context.Context, name string) error {
+	url := c.endpoint.JoinPath("/api/rgw/roles", name).String()
+	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("unable to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Accept", "application/vnd.ceph.api.v1.0+json")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.token)
+
+	logRequest := logAPIRequest(ctx, httpReq)
+	httpResp, err := c.client.Do(httpReq)
+	logRequest(httpResp, err)
+	if err != nil {
+		return fmt.Errorf("unable to make request to Ceph API: %w", err)
+	}
+	defer httpResp.Body.Close() //nolint:errcheck
+
+	if httpResp.StatusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
+
+	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusAccepted && httpResp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(httpResp.Body)
+		if dashboardErr, err := parseDashboardError(body); err == nil {
+			if rgwErr, ok := dashboardErr.RGWError(); ok {
+				if rgwErr.Code == "NoSuchEntity" {
+					return ErrNotFound
+				}
+			}
+		}
+		return fmt.Errorf("ceph API returned status %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	return nil
+}

--- a/provider.go
+++ b/provider.go
@@ -212,6 +212,7 @@ func (p *CephProvider) Resources(ctx context.Context) []func() resource.Resource
 		newPoolResource,
 		newRBDImageResource,
 		newRGWBucketResource,
+		newRGWRoleResource,
 		newRGWS3KeyResource,
 		newRGWUserResource,
 	}
@@ -231,6 +232,7 @@ func (p *CephProvider) DataSources(ctx context.Context) []func() datasource.Data
 		newPoolDataSource,
 		newRBDImageDataSource,
 		newRGWBucketDataSource,
+		newRGWRoleDataSource,
 		newRGWS3KeyDataSource,
 		newRGWSubuserDataSource,
 		newRGWSwiftKeyDataSource,

--- a/rgw_role_data_source.go
+++ b/rgw_role_data_source.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/josh/terraform-provider-ceph/internal/restapi"
+)
+
+var _ datasource.DataSource = &RGWRoleDataSource{}
+
+func newRGWRoleDataSource() datasource.DataSource {
+	return &RGWRoleDataSource{}
+}
+
+type RGWRoleDataSource struct {
+	client *restapi.Client
+}
+
+type RGWRoleDataSourceModel struct {
+	Name                     types.String `tfsdk:"name"`
+	Path                     types.String `tfsdk:"path"`
+	AssumeRolePolicyDocument types.String `tfsdk:"assume_role_policy_document"`
+	MaxSessionDuration       types.Int64  `tfsdk:"max_session_duration"`
+	ID                       types.String `tfsdk:"id"`
+	RoleID                   types.String `tfsdk:"role_id"`
+	Arn                      types.String `tfsdk:"arn"`
+	CreateDate               types.String `tfsdk:"create_date"`
+	AccountID                types.String `tfsdk:"account_id"`
+}
+
+func (d *RGWRoleDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_rgw_role"
+}
+
+func (d *RGWRoleDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = dataSourceSchema.Schema{
+		MarkdownDescription: "This data source allows you to get information about a Ceph RGW IAM role.",
+		Attributes: map[string]dataSourceSchema.Attribute{
+			"name": dataSourceSchema.StringAttribute{
+				MarkdownDescription: "The name of the role.",
+				Required:            true,
+			},
+			"path": dataSourceSchema.StringAttribute{
+				MarkdownDescription: "The path to the role.",
+				Computed:            true,
+			},
+			"assume_role_policy_document": dataSourceSchema.StringAttribute{
+				MarkdownDescription: "The trust relationship policy document that grants an entity permission to assume the role.",
+				Computed:            true,
+			},
+			"max_session_duration": dataSourceSchema.Int64Attribute{
+				MarkdownDescription: "The maximum session duration in seconds for the role.",
+				Computed:            true,
+			},
+			"id": dataSourceSchema.StringAttribute{
+				MarkdownDescription: "The name of the role.",
+				Computed:            true,
+			},
+			"role_id": dataSourceSchema.StringAttribute{
+				MarkdownDescription: "The internal id of the role.",
+				Computed:            true,
+			},
+			"arn": dataSourceSchema.StringAttribute{
+				MarkdownDescription: "The Amazon Resource Name (ARN) of the role.",
+				Computed:            true,
+			},
+			"create_date": dataSourceSchema.StringAttribute{
+				MarkdownDescription: "The date and time the role was created.",
+				Computed:            true,
+			},
+			"account_id": dataSourceSchema.StringAttribute{
+				MarkdownDescription: "The account id the role belongs to.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (d *RGWRoleDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*restapi.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *restapi.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+func (d *RGWRoleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data RGWRoleDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	role, err := d.client.RGWGetRole(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"API Request Error",
+			fmt.Sprintf("Unable to get RGW role from Ceph API: %s", err),
+		)
+		return
+	}
+
+	data.Name = types.StringValue(role.RoleName)
+	data.Path = types.StringValue(role.Path)
+	data.AssumeRolePolicyDocument = types.StringValue(role.AssumeRolePolicyDocument)
+	data.MaxSessionDuration = types.Int64Value(role.MaxSessionDuration)
+	data.ID = types.StringValue(role.RoleName)
+	data.RoleID = types.StringValue(role.RoleID)
+	data.Arn = types.StringValue(role.Arn)
+	data.CreateDate = types.StringValue(role.CreateDate)
+	data.AccountID = types.StringValue(role.AccountID)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/rgw_role_data_source_test.go
+++ b/rgw_role_data_source_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCephRGWRoleDataSource(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	roleName := acctest.RandomWithPrefix("test-role-ds")
+	assumePolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam:::user/someuser"},"Action":"sts:AssumeRole"}]}`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck: func() {
+			createTestRGWRoleDirectly(t, roleName, "/", assumePolicy)
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					data "ceph_rgw_role" "test" {
+					  name = %q
+					}
+				`, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ceph_rgw_role.test", "name", roleName),
+					resource.TestCheckResourceAttr("data.ceph_rgw_role.test", "id", roleName),
+					resource.TestCheckResourceAttr("data.ceph_rgw_role.test", "path", "/"),
+					resource.TestCheckResourceAttr("data.ceph_rgw_role.test", "max_session_duration", "3600"),
+					resource.TestCheckResourceAttrSet("data.ceph_rgw_role.test", "arn"),
+					resource.TestCheckResourceAttrSet("data.ceph_rgw_role.test", "role_id"),
+					resource.TestCheckResourceAttrSet("data.ceph_rgw_role.test", "assume_role_policy_document"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCephRGWRoleDataSource_nonExistent(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + `
+					data "ceph_rgw_role" "nonexistent" {
+					  name = "nonexistent-role-12345"
+					}
+				`,
+				ExpectError: regexp.MustCompile(`(?i)unable to get rgw role from ceph api`),
+			},
+		},
+	})
+}

--- a/rgw_role_resource.go
+++ b/rgw_role_resource.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/josh/terraform-provider-ceph/internal/restapi"
+)
+
+var (
+	_ resource.Resource                = &RGWRoleResource{}
+	_ resource.ResourceWithImportState = &RGWRoleResource{}
+)
+
+func newRGWRoleResource() resource.Resource {
+	return &RGWRoleResource{}
+}
+
+type RGWRoleResource struct {
+	client *restapi.Client
+}
+
+type RGWRoleResourceModel struct {
+	Name                     types.String `tfsdk:"name"`
+	Path                     types.String `tfsdk:"path"`
+	AssumeRolePolicyDocument types.String `tfsdk:"assume_role_policy_document"`
+	MaxSessionDuration       types.Int64  `tfsdk:"max_session_duration"`
+	ID                       types.String `tfsdk:"id"`
+	RoleID                   types.String `tfsdk:"role_id"`
+	Arn                      types.String `tfsdk:"arn"`
+	CreateDate               types.String `tfsdk:"create_date"`
+	AccountID                types.String `tfsdk:"account_id"`
+}
+
+func (r *RGWRoleResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_rgw_role"
+}
+
+func (r *RGWRoleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resourceSchema.Schema{
+		MarkdownDescription: "This resource manages a Ceph RGW IAM role.",
+		Attributes: map[string]resourceSchema.Attribute{
+			"name": resourceSchema.StringAttribute{
+				MarkdownDescription: "The name of the role. Changing requires destroying and recreating the role.",
+				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(64),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"path": resourceSchema.StringAttribute{
+				MarkdownDescription: "The path to the role. Must be an absolute path beginning and ending with a slash. Changing requires destroying and recreating the role.",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("/"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"assume_role_policy_document": resourceSchema.StringAttribute{
+				MarkdownDescription: "The trust relationship policy document that grants an entity permission to assume the role, as a JSON string. Changing requires destroying and recreating the role.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"max_session_duration": resourceSchema.Int64Attribute{
+				MarkdownDescription: "The maximum session duration in seconds for the role. Must be between 3600 (1 hour) and 43200 (12 hours).",
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(3600),
+				Validators: []validator.Int64{
+					int64validator.Between(3600, 43200),
+				},
+			},
+			"id": resourceSchema.StringAttribute{
+				MarkdownDescription: "The name of the role.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"role_id": resourceSchema.StringAttribute{
+				MarkdownDescription: "The internal id of the role.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"arn": resourceSchema.StringAttribute{
+				MarkdownDescription: "The Amazon Resource Name (ARN) of the role.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"create_date": resourceSchema.StringAttribute{
+				MarkdownDescription: "The date and time the role was created.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"account_id": resourceSchema.StringAttribute{
+				MarkdownDescription: "The account id the role belongs to.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *RGWRoleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*restapi.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *restapi.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *RGWRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data RGWRoleResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.Name.ValueString()
+	err := r.client.RGWCreateRole(ctx, restapi.RGWRoleCreateRequest{
+		RoleName:            name,
+		RolePath:            data.Path.ValueString(),
+		RoleAssumePolicyDoc: data.AssumeRolePolicyDocument.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"API Request Error",
+			fmt.Sprintf("Unable to create RGW role: %s", err),
+		)
+		return
+	}
+
+	if data.MaxSessionDuration.ValueInt64() != 3600 {
+		if err := r.client.RGWUpdateRole(ctx, name, data.MaxSessionDuration.ValueInt64()); err != nil {
+			resp.Diagnostics.AddError(
+				"API Request Error",
+				fmt.Sprintf("Unable to set max session duration on RGW role: %s", err),
+			)
+			return
+		}
+	}
+
+	role, err := r.client.RGWGetRole(ctx, name)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"API Request Error",
+			fmt.Sprintf("Unable to read RGW role after creation: %s", err),
+		)
+		return
+	}
+
+	updateModelFromAPIRole(&data, role)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *RGWRoleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data RGWRoleResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	role, err := r.client.RGWGetRole(ctx, data.Name.ValueString())
+	if err != nil {
+		if errors.Is(err, restapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"API Request Error",
+			fmt.Sprintf("Unable to read RGW role: %s", err),
+		)
+		return
+	}
+
+	updateModelFromAPIRole(&data, role)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *RGWRoleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data RGWRoleResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.Name.ValueString()
+	err := r.client.RGWUpdateRole(ctx, name, data.MaxSessionDuration.ValueInt64())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"API Request Error",
+			fmt.Sprintf("Unable to update RGW role: %s", err),
+		)
+		return
+	}
+
+	role, err := r.client.RGWGetRole(ctx, name)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"API Request Error",
+			fmt.Sprintf("Unable to read RGW role after update: %s", err),
+		)
+		return
+	}
+
+	updateModelFromAPIRole(&data, role)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *RGWRoleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data RGWRoleResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RGWDeleteRole(ctx, data.Name.ValueString())
+	if err != nil {
+		if errors.Is(err, restapi.ErrNotFound) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			"API Request Error",
+			fmt.Sprintf("Unable to delete RGW role: %s", err),
+		)
+		return
+	}
+}
+
+func (r *RGWRoleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+}
+
+func updateModelFromAPIRole(data *RGWRoleResourceModel, role *restapi.RGWRole) {
+	data.Name = types.StringValue(role.RoleName)
+	data.Path = types.StringValue(role.Path)
+	data.MaxSessionDuration = types.Int64Value(role.MaxSessionDuration)
+	data.ID = types.StringValue(role.RoleName)
+	data.RoleID = types.StringValue(role.RoleID)
+	data.Arn = types.StringValue(role.Arn)
+	data.CreateDate = types.StringValue(role.CreateDate)
+	data.AccountID = types.StringValue(role.AccountID)
+
+	// Preserve the configured document when it is semantically equal to the
+	// value returned by Ceph to avoid perpetual diffs from JSON formatting.
+	if !jsonStringsEqual(data.AssumeRolePolicyDocument.ValueString(), role.AssumeRolePolicyDocument) {
+		data.AssumeRolePolicyDocument = types.StringValue(role.AssumeRolePolicyDocument)
+	}
+}
+
+func jsonStringsEqual(a, b string) bool {
+	var av, bv any
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
+}

--- a/rgw_role_resource_test.go
+++ b/rgw_role_resource_test.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/josh/terraform-provider-ceph/internal/cephcli"
+)
+
+const testAccRGWRoleAssumePolicy = `jsonencode({
+  Version = "2012-10-17"
+  Statement = [{
+    Effect    = "Allow"
+    Principal = { AWS = "arn:aws:iam:::user/%s" }
+    Action    = "sts:AssumeRole"
+  }]
+})`
+
+func TestAccCephRGWRoleResource(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	roleName := acctest.RandomWithPrefix("test-role")
+	principal := acctest.RandomWithPrefix("test-principal")
+	assumePolicy := fmt.Sprintf(testAccRGWRoleAssumePolicy, principal)
+	otherPolicy := fmt.Sprintf(testAccRGWRoleAssumePolicy, principal+"-other")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephRGWRoleDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_rgw_role" "test" {
+					  name                        = %q
+					  assume_role_policy_document = %s
+					}
+				`, roleName, assumePolicy),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ceph_rgw_role.test",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(roleName),
+					),
+					statecheck.ExpectKnownValue(
+						"ceph_rgw_role.test",
+						tfjsonpath.New("path"),
+						knownvalue.StringExact("/"),
+					),
+					statecheck.ExpectKnownValue(
+						"ceph_rgw_role.test",
+						tfjsonpath.New("max_session_duration"),
+						knownvalue.Int64Exact(3600),
+					),
+					statecheck.ExpectKnownValue(
+						"ceph_rgw_role.test",
+						tfjsonpath.New("arn"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"ceph_rgw_role.test",
+						tfjsonpath.New("role_id"),
+						knownvalue.NotNull(),
+					),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkCephRGWRoleExists(t, roleName),
+					resource.TestCheckResourceAttr("ceph_rgw_role.test", "name", roleName),
+					resource.TestCheckResourceAttr("ceph_rgw_role.test", "id", roleName),
+					resource.TestCheckResourceAttrSet("ceph_rgw_role.test", "arn"),
+					checkCephRGWRoleMaxSessionDuration(t, roleName, 3600),
+				),
+			},
+			// Update the only mutable attribute in place.
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_rgw_role" "test" {
+					  name                        = %q
+					  assume_role_policy_document = %s
+					  max_session_duration        = 7200
+					}
+				`, roleName, assumePolicy),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ceph_rgw_role.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ceph_rgw_role.test",
+						tfjsonpath.New("max_session_duration"),
+						knownvalue.Int64Exact(7200),
+					),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkCephRGWRoleExists(t, roleName),
+					checkCephRGWRoleMaxSessionDuration(t, roleName, 7200),
+				),
+			},
+			// Re-applying the same config must be a no-op (guards against JSON drift).
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_rgw_role" "test" {
+					  name                        = %q
+					  assume_role_policy_document = %s
+					  max_session_duration        = 7200
+					}
+				`, roleName, assumePolicy),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Changing the trust policy forces replacement.
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_rgw_role" "test" {
+					  name                        = %q
+					  assume_role_policy_document = %s
+					  max_session_duration        = 7200
+					}
+				`, roleName, otherPolicy),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ceph_rgw_role.test", plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkCephRGWRoleExists(t, roleName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCephRGWRoleResource_customPath(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	roleName := acctest.RandomWithPrefix("test-role-path")
+	assumePolicy := fmt.Sprintf(testAccRGWRoleAssumePolicy, "someuser")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephRGWRoleDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_rgw_role" "test" {
+					  name                        = %q
+					  path                        = "/application/"
+					  assume_role_policy_document = %s
+					}
+				`, roleName, assumePolicy),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ceph_rgw_role.test",
+						tfjsonpath.New("path"),
+						knownvalue.StringExact("/application/"),
+					),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkCephRGWRoleExists(t, roleName),
+					resource.TestCheckResourceAttr("ceph_rgw_role.test", "path", "/application/"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCephRGWRoleResource_invalidMaxSessionDuration(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	roleName := acctest.RandomWithPrefix("test-role-invalid")
+	assumePolicy := fmt.Sprintf(testAccRGWRoleAssumePolicy, "someuser")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_rgw_role" "test" {
+					  name                        = %q
+					  assume_role_policy_document = %s
+					  max_session_duration        = 60
+					}
+				`, roleName, assumePolicy),
+				ExpectError: regexp.MustCompile(`(?i)max_session_duration`),
+			},
+		},
+	})
+}
+
+func TestAccCephRGWRoleResourceImport(t *testing.T) {
+	detachLogs := cephDaemonLogs.AttachTestFunction(t)
+	defer detachLogs()
+
+	roleName := acctest.RandomWithPrefix("test-role-import")
+	assumePolicy := fmt.Sprintf(testAccRGWRoleAssumePolicy, "someuser")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCephRGWRoleDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_rgw_role" "test" {
+					  name                        = %q
+					  assume_role_policy_document = %s
+					}
+				`, roleName, assumePolicy),
+			},
+			{
+				ConfigVariables: testAccProviderConfig(),
+				Config: testAccProviderConfigBlock + fmt.Sprintf(`
+					resource "ceph_rgw_role" "test" {
+					  name                        = %q
+					  assume_role_policy_document = %s
+					}
+				`, roleName, assumePolicy),
+				ResourceName:                         "ceph_rgw_role.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateId:                        roleName,
+				// Ceph may re-serialize the stored trust policy; the managed
+				// resource tolerates that via semantic comparison, but the
+				// import verifier compares raw strings.
+				ImportStateVerifyIgnore: []string{"assume_role_policy_document"},
+			},
+		},
+	})
+}
+
+func testAccCheckCephRGWRoleDestroy(t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ctx := t.Context()
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "ceph_rgw_role" {
+				continue
+			}
+
+			exists, err := cephTestClusterCLI.RGWRoleExists(ctx, rs.Primary.Attributes["name"])
+			if err != nil {
+				return err
+			}
+			if exists {
+				return fmt.Errorf("ceph_rgw_role resource %s still exists", rs.Primary.Attributes["name"])
+			}
+		}
+		return nil
+	}
+}
+
+func checkCephRGWRoleExists(t *testing.T, name string) resource.TestCheckFunc {
+	t.Helper()
+	return func(s *terraform.State) error {
+		exists, err := cephTestClusterCLI.RGWRoleExists(t.Context(), name)
+		if err != nil {
+			return fmt.Errorf("RGW role %s existence check failed: %w", name, err)
+		}
+		if !exists {
+			return fmt.Errorf("RGW role %s does not exist", name)
+		}
+		return nil
+	}
+}
+
+func checkCephRGWRoleMaxSessionDuration(t *testing.T, name string, expected int64) resource.TestCheckFunc {
+	t.Helper()
+	return func(s *terraform.State) error {
+		role, err := cephTestClusterCLI.RGWRoleGet(t.Context(), name)
+		if err != nil {
+			return fmt.Errorf("radosgw-admin failed to get role %s: %w", name, err)
+		}
+		if role.MaxSessionDuration != expected {
+			return fmt.Errorf("expected role %s max_session_duration=%d, got %d", name, expected, role.MaxSessionDuration)
+		}
+		return nil
+	}
+}
+
+func createTestRGWRoleDirectly(t *testing.T, name, path, assumePolicyDoc string) {
+	t.Helper()
+
+	if err := cephTestClusterCLI.RGWRoleCreate(t.Context(), name, path, assumePolicyDoc); err != nil {
+		t.Fatalf("Failed to pre-create test RGW role: %v", err)
+	}
+
+	t.Logf("Pre-created test RGW role: %s", name)
+
+	testCleanup(t, func(ctx context.Context) {
+		if err := cephTestClusterCLI.RGWRoleDelete(ctx, name); err != nil && !errors.Is(err, cephcli.ErrRGWRoleNotFound) {
+			t.Fatalf("Failed to cleanup RGW role %s: %v", name, err)
+		}
+	})
+}


### PR DESCRIPTION
Model RGW IAM roles via the dashboard /api/rgw/roles CRUD endpoint, covering create, read, in-place max_session_duration update, replace, import, and delete. Roles have no single-item GET, so reads filter the list by name. The edit endpoint interprets max_session_duration in hours while the read endpoint reports seconds, so the client converts on write.